### PR TITLE
Correct Colors in Nord Theme

### DIFF
--- a/lua/base16-colorscheme.lua
+++ b/lua/base16-colorscheme.lua
@@ -847,8 +847,8 @@ M.colorschemes['monokai'] = {
 M.colorschemes['nord'] = {
     base00 = '#2E3440', base01 = '#3B4252', base02 = '#434C5E', base03 = '#4C566A',
     base04 = '#D8DEE9', base05 = '#E5E9F0', base06 = '#ECEFF4', base07 = '#8FBCBB',
-    base08 = '#88C0D0', base09 = '#81A1C1', base0A = '#5E81AC', base0B = '#BF616A',
-    base0C = '#D08770', base0D = '#EBCB8B', base0E = '#A3BE8C', base0F = '#B48EAD',
+    base08 = '#BF616A', base09 = '#D08770', base0A = '#EBCB8B', base0B = '#A3BE8C',
+    base0C = '#88C0D0', base0D = '#81A1C1', base0E = '#B48EAD', base0F = '#5E81AC',
 }
 M.colorschemes['ocean'] = {
     base00 = '#2b303b', base01 = '#343d46', base02 = '#4f5b66', base03 = '#65737e',


### PR DESCRIPTION
Use updates from https://github.com/spejamchr/base16-nord-scheme to fix colors for the nord theme.