### PR TITLE
Add TSSymbol highlight group

### DIFF
--- a/lua/base16-colorscheme.lua
+++ b/lua/base16-colorscheme.lua
@@ -201,6 +201,7 @@ function M.setup(colors)
     hi.TSString             = { guifg = M.colors.base0B, guibg = nil, gui = NONE,            guisp = nil }
     hi.TSStringRegex        = { guifg = M.colors.base0B, guibg = nil, gui = NONE,            guisp = nil }
     hi.TSStringEscape       = { guifg = M.colors.base0C, guibg = nil, gui = NONE,            guisp = nil }
+    hi.TSSymbol             = { guifg = M.colors.base0B, guibg = nil, gui = NONE,            guisp = nil }
     hi.TSTag                = { guifg = M.colors.base0A, guibg = nil, gui = NONE,            guisp = nil }
     hi.TSTagDelimiter       = { guifg = M.colors.base0F, guibg = nil, gui = NONE,            guisp = nil }
     hi.TSText               = { guifg = M.colors.base05, guibg = nil, gui = NONE,            guisp = nil }


### PR DESCRIPTION
This adds the `TSSymbol` highlight group that was introduced in https://github.com/nvim-treesitter/nvim-treesitter/pull/982.

I've set the color to the one used in https://github.com/chriskempson/base16-vim/blob/6191622d5806d4448fa2285047936bdcee57a098/colors/base16-ocean.vim#L372 as a reference point.

Thanks for an ✨ project!