### PR TITLE
Change SignColumn guibg to match GitGutter

### DIFF
--- a/lua/base16-colorscheme.lua
+++ b/lua/base16-colorscheme.lua
@@ -90,7 +90,7 @@ function M.setup(colors)
     hi.Cursor       = { guifg = M.colors.base00, guibg = M.colors.base05, gui = nil,    guisp = nil }
     hi.NonText      = { guifg = M.colors.base03, guibg = nil,             gui = nil,    guisp = nil }
     hi.LineNr       = { guifg = M.colors.base04, guibg = M.colors.base00, gui = nil,    guisp = nil }
-    hi.SignColumn   = { guifg = M.colors.base04, guibg = M.colors.base00, gui = nil,    guisp = nil }
+    hi.SignColumn   = { guifg = M.colors.base04, guibg = M.colors.base01, gui = nil,    guisp = nil }
     hi.StatusLine   = { guifg = M.colors.base04, guibg = M.colors.base02, gui = 'none', guisp = nil }
     hi.StatusLineNC = { guifg = M.colors.base03, guibg = M.colors.base01, gui = 'none', guisp = nil }
     hi.VertSplit    = { guifg = M.colors.base05, guibg = M.colors.base00, gui = 'none', guisp = nil }


### PR DESCRIPTION
It looks strange if they don't match. There's a choice between which guibg color to use. I prefer distinguishing SignColumn (rather than matching Normal) as this is how it is in https://github.com/chriskempson/base16-vim/blob/master/colors/base16-tomorrow-night.vim#L212.

Before:
![image](https://user-images.githubusercontent.com/5385846/122692481-2a781f80-d1ea-11eb-93bd-ad8b52f5326c.png)

After:
![image](https://user-images.githubusercontent.com/5385846/122692645-39ab9d00-d1eb-11eb-96a8-3a4e6f9b3638.png)

Edit: I just noticed [LineNr](https://github.com/chriskempson/base16-vim/blob/master/colors/base16-tomorrow-night.vim#L211) uses 01 as well. Let me know if you want to change that here.