### PR TITLE
Leave old highlight groups for previous Neovim versions

### DIFF
--- a/lua/base16-colorscheme.lua
+++ b/lua/base16-colorscheme.lua
@@ -185,14 +185,14 @@ function M.setup(colors)
     hi.DiagnosticUnderlineWarning         = { guifg = nil,             guibg = nil, gui = 'undercurl', guisp = M.colors.base0E }
     hi.DiagnosticUnderlineInformation     = { guifg = nil,             guibg = nil, gui = 'undercurl', guisp = M.colors.base0F }
     hi.DiagnosticUnderlineHint            = { guifg = nil,             guibg = nil, gui = 'undercurl', guisp = M.colors.base0C }
-    hi.LspDiagnosticsDefaultError         = hi.DiagnosticError
-    hi.LspDiagnosticsDefaultWarning       = hi.DiagnosticWarn
-    hi.LspDiagnosticsDefaultInformation   = hi.DiagnosticInfo
-    hi.LspDiagnosticsDefaultHint          = hi.DiagnosticHint
-    hi.LspDiagnosticsUnderlineError       = hi.DiagnosticUnderlineError
-    hi.LspDiagnosticsUnderlineWarning     = hi.DiagnosticUnderlineWarning
-    hi.LspDiagnosticsUnderlineInformation = hi.DiagnosticUnderlineInformation
-    hi.LspDiagnosticsUnderlineHint        = hi.DiagnosticUnderlineHint
+    hi.LspDiagnosticsDefaultError         = { guifg = M.colors.base08, guibg = nil, gui = 'none',      guisp = nil             }
+    hi.LspDiagnosticsDefaultWarning       = { guifg = M.colors.base0E, guibg = nil, gui = 'none',      guisp = nil             }
+    hi.LspDiagnosticsDefaultInformation   = { guifg = M.colors.base05, guibg = nil, gui = 'none',      guisp = nil             }
+    hi.LspDiagnosticsDefaultHint          = { guifg = M.colors.base0C, guibg = nil, gui = 'none',      guisp = nil             }
+    hi.LspDiagnosticsUnderlineError       = { guifg = nil,             guibg = nil, gui = 'undercurl', guisp = M.colors.base08 }
+    hi.LspDiagnosticsUnderlineWarning     = { guifg = nil,             guibg = nil, gui = 'undercurl', guisp = M.colors.base0E }
+    hi.LspDiagnosticsUnderlineInformation = { guifg = nil,             guibg = nil, gui = 'undercurl', guisp = M.colors.base0F }
+    hi.LspDiagnosticsUnderlineHint        = { guifg = nil,             guibg = nil, gui = 'undercurl', guisp = M.colors.base0C }
 
     hi.TSAnnotation         = { guifg = M.colors.base0F, guibg = nil, gui = 'none',          guisp = nil }
     hi.TSAttribute          = { guifg = M.colors.base0A, guibg = nil, gui = 'none',          guisp = nil }


### PR DESCRIPTION
It seems my previous PR is broken, since `__newindex` doesn't assign any object, just creates a hl group and I'm trying to read table field (e.g. `hi.LspDiagnosticsUnderlineError = hi.DiagnosticUnderlineError`). So there's a fix :)