### PR TITLE
Reuse groups by linking them

### DIFF
--- a/lua/base16-colorscheme.lua
+++ b/lua/base16-colorscheme.lua
@@ -199,9 +199,6 @@ function M.setup(colors)
     hi.SpellCap   = { guifg = nil, guibg = nil, gui = 'undercurl', guisp = M.colors.base0D }
     hi.SpellRare  = { guifg = nil, guibg = nil, gui = 'undercurl', guisp = M.colors.base0E }
 
-    hi.LspReferenceText                   = { guifg = nil,             guibg = nil, gui = 'underline', guisp = M.colors.base04 }
-    hi.LspReferenceRead                   = { guifg = nil,             guibg = nil, gui = 'underline', guisp = M.colors.base04 }
-    hi.LspReferenceWrite                  = { guifg = nil,             guibg = nil, gui = 'underline', guisp = M.colors.base04 }
     hi.DiagnosticError                    = { guifg = M.colors.base08, guibg = nil, gui = 'none',      guisp = nil             }
     hi.DiagnosticWarn                     = { guifg = M.colors.base0E, guibg = nil, gui = 'none',      guisp = nil             }
     hi.DiagnosticInfo                     = { guifg = M.colors.base05, guibg = nil, gui = 'none',      guisp = nil             }
@@ -210,14 +207,18 @@ function M.setup(colors)
     hi.DiagnosticUnderlineWarning         = { guifg = nil,             guibg = nil, gui = 'undercurl', guisp = M.colors.base0E }
     hi.DiagnosticUnderlineInformation     = { guifg = nil,             guibg = nil, gui = 'undercurl', guisp = M.colors.base0F }
     hi.DiagnosticUnderlineHint            = { guifg = nil,             guibg = nil, gui = 'undercurl', guisp = M.colors.base0C }
-    hi.LspDiagnosticsDefaultError         = { guifg = M.colors.base08, guibg = nil, gui = 'none',      guisp = nil             }
-    hi.LspDiagnosticsDefaultWarning       = { guifg = M.colors.base0E, guibg = nil, gui = 'none',      guisp = nil             }
-    hi.LspDiagnosticsDefaultInformation   = { guifg = M.colors.base05, guibg = nil, gui = 'none',      guisp = nil             }
-    hi.LspDiagnosticsDefaultHint          = { guifg = M.colors.base0C, guibg = nil, gui = 'none',      guisp = nil             }
-    hi.LspDiagnosticsUnderlineError       = { guifg = nil,             guibg = nil, gui = 'undercurl', guisp = M.colors.base08 }
-    hi.LspDiagnosticsUnderlineWarning     = { guifg = nil,             guibg = nil, gui = 'undercurl', guisp = M.colors.base0E }
-    hi.LspDiagnosticsUnderlineInformation = { guifg = nil,             guibg = nil, gui = 'undercurl', guisp = M.colors.base0F }
-    hi.LspDiagnosticsUnderlineHint        = { guifg = nil,             guibg = nil, gui = 'undercurl', guisp = M.colors.base0C }
+
+    hi.LspReferenceText                   = { guifg = nil,             guibg = nil, gui = 'underline', guisp = M.colors.base04 }
+    hi.LspReferenceRead                   = { guifg = nil,             guibg = nil, gui = 'underline', guisp = M.colors.base04 }
+    hi.LspReferenceWrite                  = { guifg = nil,             guibg = nil, gui = 'underline', guisp = M.colors.base04 }
+    hi.LspDiagnosticsDefaultError         = 'DiagnosticError'
+    hi.LspDiagnosticsDefaultWarning       = 'DiagnosticWarn'
+    hi.LspDiagnosticsDefaultInformation   = 'DiagnosticInfo'
+    hi.LspDiagnosticsDefaultHint          = 'DiagnosticHint'
+    hi.LspDiagnosticsUnderlineError       = 'DiagnosticUnderlineError'
+    hi.LspDiagnosticsUnderlineWarning     = 'DiagnosticUnderlineWarning'
+    hi.LspDiagnosticsUnderlineInformation = 'DiagnosticUnderlineInformation'
+    hi.LspDiagnosticsUnderlineHint        = 'DiagnosticUnderlineHint'
 
     hi.TSAnnotation         = { guifg = M.colors.base0F, guibg = nil, gui = 'none',          guisp = nil }
     hi.TSAttribute          = { guifg = M.colors.base0A, guibg = nil, gui = 'none',          guisp = nil }

--- a/lua/base16-colorscheme.lua
+++ b/lua/base16-colorscheme.lua
@@ -6,18 +6,43 @@
 
 local M = {}
 
+local function validate_hilight_args(args)
+    if 'string' == type(args) then
+        return true
+    end
+
+    if 'table' ~= type(args) then
+        return 'args must either be a string or a table'
+    end
+
+    return nil ~= (args.guifg or args.guibg or args.gui or args.guisp),
+        'args must contains at least one of: guifg, guibg, gui, guisp'
+end
+
 -- This is a bit of syntactic sugar for creating highlight groups.
 --
 -- local colorscheme = require('colorscheme')
 -- local hi = colorscheme.highlight
 -- hi.Comment = { guifg='#ffffff', guibg='#000000', gui='italic', guisp=nil }
+-- hi.LspDiagnosticsDefaultError = 'DiagnosticError' -- Link to another group
 --
 -- This is equivalent to the following vimscript
 --
 -- hi Comment guifg=#ffffff guibg=#000000 gui=italic
+-- hi! link LspDiagnosticsDefaultError DiagnosticError
 M.highlight = setmetatable({}, {
     __newindex = function(_, hlgroup, args)
-        local guifg, guibg, gui, guisp = args.guifg, args.guibg, args.gui, args.guisp
+        vim.validate {
+            hlgroup = { hlgroup, 'string' },
+            args = { args, validate_hilight_args, 'string or table' },
+        }
+
+        if ('string' == type(args)) then
+            vim.cmd(('hi! link %s %s'):format(hlgroup, args))
+            return
+        end
+
+        local guifg, guibg, gui, guisp = args.guifg or nil, args.guibg or nil, args.gui or nil, args.guisp or nil
         local cmd = {'hi', hlgroup}
         if guifg then table.insert(cmd, 'guifg='..guifg) end
         if guibg then table.insert(cmd, 'guibg='..guibg) end


### PR DESCRIPTION
Hi

This is a proposal to link groups instead of copying their definition, see: https://github.com/RRethy/nvim-base16/pull/23

I think it will make it easier for any user to tweak into the base16 colorschemes when needed because it's a way to keep a colorscheme coherent.

Although it can be quite convenient it should not be abused.
IMO we should only link groups together if it make sense for them to change together.
The diagnostics and LSP diagnostics group are a pretty good example. No matter from where the diagnostics come from I will expect them to be represented it the same fashion.
Another example could be the Treesitter groups which overlaps with the standard ones like `Normal`, `Character`, `Comment`, etc. Allowing a matching rendering no matter which of the groups are used.

I'm not well versed enough in Vim's highlighting system to be able to create those links or de understand the difference between `gui = nil` and `gui = 'none'`, so instead of risking to break something I didn't provide any link in this PR.
At the exception of the one introduced lately for the diagnostics because it was the original attempt of the PR's author.

P.S.: Thanks for the work you've done here, using base16 for many years now and it was a pleasure to find this repository with LSP + Treesitter support :cupid: 