### PR TITLE
Use base01 for contrasting floating windows against main window

### DIFF
--- a/lua/base16-colorscheme.lua
+++ b/lua/base16-colorscheme.lua
@@ -260,7 +260,7 @@ function M.setup(colors)
 
     hi.NvimInternalError = { guifg = M.colors.base00, guibg = M.colors.base08, gui = 'none', guisp = nil }
 
-    hi.NormalFloat  = { guifg = M.colors.base05, guibg = M.colors.base00, gui = nil,    guisp = nil }
+    hi.NormalFloat  = { guifg = M.colors.base05, guibg = M.colors.base01, gui = nil,    guisp = nil }
     hi.FloatBorder  = { guifg = M.colors.base05, guibg = M.colors.base00, gui = nil,    guisp = nil }
     hi.NormalNC     = { guifg = M.colors.base05, guibg = M.colors.base00, gui = nil,    guisp = nil }
     hi.TermCursor   = { guifg = M.colors.base00, guibg = M.colors.base05, gui = 'none', guisp = nil }


### PR DESCRIPTION
Currently hover windows don't appear properly because their background color is base00 which is shared with the main window. This branch changes the background color for these windows to base01.

Before: 
![image](https://user-images.githubusercontent.com/53116839/140184327-493a22b6-dfa8-4152-915e-8067dafdb710.png)

Now:
![image](https://user-images.githubusercontent.com/53116839/140184193-dc264adb-edb6-4036-bfd7-e5042133e7ed.png)
