### PR TITLE
Support nvim-ts-rainbow

### DIFF
--- a/lua/base16-colorscheme.lua
+++ b/lua/base16-colorscheme.lua
@@ -312,6 +312,15 @@ function M.setup(colors, config)
     hi.TSDefinitionUsage = { guifg = nil, guibg = nil, gui = 'underline', guisp = M.colors.base04 }
     hi.TSCurrentScope    = { guifg = nil, guibg = nil, gui = 'bold',      guisp = nil }
 
+    -- nvim-ts-rainbow
+    hi.rainbowcol1 = { guifg = M.colors.base08 }
+    hi.rainbowcol2 = { guifg = M.colors.base09 }
+    hi.rainbowcol3 = { guifg = M.colors.base0A }
+    hi.rainbowcol4 = { guifg = M.colors.base0B }
+    hi.rainbowcol5 = { guifg = M.colors.base0C }
+    hi.rainbowcol6 = { guifg = M.colors.base0D }
+    hi.rainbowcol7 = { guifg = M.colors.base0E }
+    
     hi.NvimInternalError = { guifg = M.colors.base00, guibg = M.colors.base08, gui = 'none', guisp = nil }
 
     hi.NormalFloat  = { guifg = M.colors.base05, guibg = M.colors.base00, gui = nil,    guisp = nil }


### PR DESCRIPTION
Support https://github.com/p00f/nvim-ts-rainbow as requested in #36. According to https://github.com/p00f/nvim-ts-rainbow#colours

I've chosen `base08` to `base0E` as colors for parenthesis for several reasons:
- `base00` to `base05` are likely to be not very colorful as they define background, cursorline, selection, comment, linenumber and cursor
- `base06` and `base07` doesn't seem to have any use by default so it might not be defined correctly in some colorschemes
- `base0F` is just punctuation so also there is chance it won't have a distinct color defined
- we are limited to 7 colors using this method so we can use these 7 colors that we are left with and are best suited in my opinion