### PR TITLE
Fix TSRepeat highlight

### DIFF
--- a/lua/base16-colorscheme.lua
+++ b/lua/base16-colorscheme.lua
@@ -293,7 +293,7 @@ function M.setup(colors, config)
     hi.TSPunctDelimiter     = { guifg = M.colors.base0F, guibg = nil, gui = 'none',          guisp = nil }
     hi.TSPunctBracket       = { guifg = M.colors.base05, guibg = nil, gui = 'none',          guisp = nil }
     hi.TSPunctSpecial       = { guifg = M.colors.base05, guibg = nil, gui = 'none',          guisp = nil }
-    hi.TSRepeat             = { guifg = M.colors.base0A, guibg = nil, gui = 'none',          guisp = nil }
+    hi.TSRepeat             = { guifg = M.colors.base0E, guibg = nil, gui = 'none',          guisp = nil }
     hi.TSString             = { guifg = M.colors.base0B, guibg = nil, gui = 'none',          guisp = nil }
     hi.TSStringRegex        = { guifg = M.colors.base0C, guibg = nil, gui = 'none',          guisp = nil }
     hi.TSStringEscape       = { guifg = M.colors.base0C, guibg = nil, gui = 'none',          guisp = nil }


### PR DESCRIPTION
`TSRepeat` matches `for` and `while` keywords in most languages, therefore the highlight should be `base0E` according to the guidelines (https://github.com/chriskempson/base16/blob/master/styling.md)