### PR TITLE
Change background color for float windows to base01

### DIFF
--- a/lua/base16-colorscheme.lua
+++ b/lua/base16-colorscheme.lua
@@ -330,7 +330,7 @@ function M.setup(colors, config)
 
     hi.NvimInternalError = { guifg = M.colors.base00, guibg = M.colors.base08, gui = 'none', guisp = nil }
 
-    hi.NormalFloat  = { guifg = M.colors.base05, guibg = M.colors.base00, gui = nil, guisp = nil }
+    hi.NormalFloat  = { guifg = M.colors.base05, guibg = M.colors.base01, gui = nil, guisp = nil }
     hi.FloatBorder  = { guifg = M.colors.base05, guibg = M.colors.base00, gui = nil, guisp = nil }
     hi.NormalNC     = { guifg = M.colors.base05, guibg = M.colors.base00, gui = nil, guisp = nil }
     hi.TermCursor   = { guifg = M.colors.base00, guibg = M.colors.base05, gui = 'none', guisp = nil }


### PR DESCRIPTION
This modification help delimiting float windows used in diagnostic or completion help when using cmp.