### PR TITLE
Add @text.diff.{add,delete}

### DIFF
--- a/lua/base16-colorscheme.lua
+++ b/lua/base16-colorscheme.lua
@@ -373,6 +373,8 @@ function M.setup(colors, config)
         hi['@namespace'] = 'TSNamespace'
         hi['@symbol'] = 'TSSymbol'
         hi['@text'] = 'TSText'
+        hi['@text.diff.add'] = 'DiffAdd'
+        hi['@text.diff.delete'] = 'DiffDelete'
         hi['@text.strong'] = 'TSStrong'
         hi['@text.emphasis'] = 'TSEmphasis'
         hi['@text.underline'] = 'TSUnderline'


### PR DESCRIPTION
This fixes highlighting of added and removed lines in diff files when using treesitter.

---

EDIT: A couple screenshots:

Before: 
![image](https://user-images.githubusercontent.com/646253/216503555-ada4e411-5205-417b-bf62-f2b389537a33.png)

After: 
![image](https://user-images.githubusercontent.com/646253/216503650-f0e33956-5cac-4402-9edc-62fd2b02e3ab.png)
