### PR TITLE
feat: Load colorscheme from `base16-shell` + fixes for `tmux`

### DIFF
--- a/lua/base16-colorscheme.lua
+++ b/lua/base16-colorscheme.lua
@@ -654,9 +654,8 @@ M.load_from_shell = function()
         "~/.vimrc_background",
     }
 
-    for _, path in pairs(shell_theme_paths)
-    do
-        local is_readable = vim.fn.filereadable(vim.fn.expand(path)) == 1 and true or false
+    for _, path in pairs(shell_theme_paths) do
+        local is_readable = vim.fn.filereadable(vim.fn.expand(path)) == 1
         if is_readable then
             vim.cmd([[let base16colorspace=256]])
             vim.cmd("source " .. path)

--- a/lua/base16-colorscheme.lua
+++ b/lua/base16-colorscheme.lua
@@ -8,28 +8,28 @@ local M = {}
 local hex_re = vim.regex('#\\x\\x\\x\\x\\x\\x')
 
 local HEX_DIGITS = {
-        ['0'] = 0,
-        ['1'] = 1,
-        ['2'] = 2,
-        ['3'] = 3,
-        ['4'] = 4,
-        ['5'] = 5,
-        ['6'] = 6,
-        ['7'] = 7,
-        ['8'] = 8,
-        ['9'] = 9,
-        ['a'] = 10,
-        ['b'] = 11,
-        ['c'] = 12,
-        ['d'] = 13,
-        ['e'] = 14,
-        ['f'] = 15,
-        ['A'] = 10,
-        ['B'] = 11,
-        ['C'] = 12,
-        ['D'] = 13,
-        ['E'] = 14,
-        ['F'] = 15,
+    ['0'] = 0,
+    ['1'] = 1,
+    ['2'] = 2,
+    ['3'] = 3,
+    ['4'] = 4,
+    ['5'] = 5,
+    ['6'] = 6,
+    ['7'] = 7,
+    ['8'] = 8,
+    ['9'] = 9,
+    ['a'] = 10,
+    ['b'] = 11,
+    ['c'] = 12,
+    ['d'] = 13,
+    ['e'] = 14,
+    ['f'] = 15,
+    ['A'] = 10,
+    ['B'] = 11,
+    ['C'] = 12,
+    ['D'] = 13,
+    ['E'] = 14,
+    ['F'] = 15,
 }
 
 local function hex_to_rgb(hex)
@@ -646,24 +646,24 @@ M.colorschemes['schemer-medium'] = {
     base0F = '#a06949',
 }
 
-M.load_from_shell = function ()
-    -- tinted-theming/base16 writes this file when a base_16_* theme is applied.
-    local set_theme_path = "$HOME/.config/tinted-theming/set_theme.lua"
-    local is_set_theme_file_readable = vim.fn.filereadable(vim.fn.expand(set_theme_path)) == 1 and true or false
-    if is_set_theme_file_readable then
-        vim.cmd([[let base16colorspace=256]])
-        vim.cmd("source " .. set_theme_path)
-        return
-    end
+M.load_from_shell = function()
+    local shell_theme_paths = {
+        -- tinted-theming/base16 writes this file
+        "~/.config/tinted-theming/set_theme.lua",
+        -- chriskempson/base16 writes this file
+        "~/.vimrc_background",
+    }
 
-    -- chriskempson/base16-shell writes this file when a base_16_* theme is applied.
-    local set_theme_vim_path = "$HOME/.vimrc_background"
-    local is_set_theme_vim_file_readable = vim.fn.filereadable(vim.fn.expand(set_theme_vim_path)) == 1 and true or false
-    if is_set_theme_vim_file_readable then
-        vim.cmd([[let base16colorspace=256]])
-        vim.cmd("source " .. set_theme_vim_path)
-        return
+    for _, path in pairs(shell_theme_paths)
+    do
+        local is_readable = vim.fn.filereadable(vim.fn.expand(path)) == 1 and true or false
+        if is_readable then
+            vim.cmd([[let base16colorspace=256]])
+            vim.cmd("source " .. path)
+            return path
+        end
     end
+    return false
 end
 
 return M

--- a/lua/base16-colorscheme.lua
+++ b/lua/base16-colorscheme.lua
@@ -653,11 +653,10 @@ M.colorschemes['schemer-medium'] = {
 }
 
 M.load_from_shell = function()
-
     -- tinted-theming/base16-shell uses XDG_CONFIG_PATH if present.
     local config_dir = vim.env.XDG_CONFIG_HOME
     if config_dir == '' then
-    config_dir = '~/.config'
+        config_dir = '~/.config'
     end
 
     local shell_theme_paths = {

--- a/lua/base16-colorscheme.lua
+++ b/lua/base16-colorscheme.lua
@@ -646,4 +646,24 @@ M.colorschemes['schemer-medium'] = {
     base0F = '#a06949',
 }
 
+M.load_from_shell = function ()
+    -- tinted-theming/base16 writes this file when a base_16_* theme is applied.
+    local set_theme_path = "$HOME/.config/tinted-theming/set_theme.lua"
+    local is_set_theme_file_readable = vim.fn.filereadable(vim.fn.expand(set_theme_path)) == 1 and true or false
+    if is_set_theme_file_readable then
+        vim.cmd([[let base16colorspace=256]])
+        vim.cmd("source " .. set_theme_path)
+        return
+    end
+
+    -- chriskempson/base16-shell writes this file when a base_16_* theme is applied.
+    local set_theme_vim_path = "$HOME/.vimrc_background"
+    local is_set_theme_vim_file_readable = vim.fn.filereadable(vim.fn.expand(set_theme_vim_path)) == 1 and true or false
+    if is_set_theme_vim_file_readable then
+        vim.cmd([[let base16colorspace=256]])
+        vim.cmd("source " .. set_theme_vim_path)
+        return
+    end
+end
+
 return M

--- a/lua/base16-colorscheme.lua
+++ b/lua/base16-colorscheme.lua
@@ -654,9 +654,9 @@ M.colorschemes['schemer-medium'] = {
 
 M.load_from_shell = function()
     local shell_theme_paths = {
-        -- tinted-theming/base16 writes this file
+        -- tinted-theming/base16-shell writes this file
         "~/.config/tinted-theming/set_theme.lua",
-        -- chriskempson/base16 writes this file
+        -- chriskempson/base16-shell writes this file
         "~/.vimrc_background",
     }
 

--- a/lua/base16-colorscheme.lua
+++ b/lua/base16-colorscheme.lua
@@ -123,7 +123,13 @@ function M.setup(colors, config)
     end
     vim.cmd('set termguicolors')
 
-    M.colors                              = colors or M.colorschemes[vim.env.BASE16_THEME] or
+    -- BASE16_THEME in a tmux session cannot be trusted because of how envs in tmux panes work.
+    local base16_colorscheme = nil
+    if vim.env.TMUX == nil then
+        -- Only trust BASE16_THEME if not inside a tmux pane:
+        base16_colorscheme = M.colorschemes[vim.env.BASE16_THEME]
+    end
+    M.colors                              = colors or base16_colorscheme or
         M.colorschemes['schemer-dark']
     local hi                              = M.highlight
 

--- a/lua/base16-colorscheme.lua
+++ b/lua/base16-colorscheme.lua
@@ -653,9 +653,16 @@ M.colorschemes['schemer-medium'] = {
 }
 
 M.load_from_shell = function()
+
+    -- tinted-theming/base16-shell uses XDG_CONFIG_PATH if present.
+    local config_dir = vim.env.XDG_CONFIG_HOME
+    if config_dir == '' then
+    config_dir = '~/.config'
+    end
+
     local shell_theme_paths = {
         -- tinted-theming/base16-shell writes this file
-        "~/.config/tinted-theming/set_theme.lua",
+        config_dir .. "/tinted-theming/set_theme.lua",
         -- chriskempson/base16-shell writes this file
         "~/.vimrc_background",
     }


### PR DESCRIPTION
Adds a Lua function that loads in the colorscheme that matches what's set by `base16-shell`:

```lua
require('base16-colorscheme').load_from_shell()
```

This supports for both https://github.com/chriskempson/base16-shell and https://github.com/tinted-theming/base16-shell alike.

See https://github.com/tinted-theming/base16-shell#neovim, under _"Tmux & Vim"_ section. I think this is the more comprehensive approach (vs reading `BASE16_THEME`) as it works for both non-tmux and tmux contexts.

The `chriskempson/base16-shell` behavior is undocumented, but it's there.

Let me know if this is a welcome change, I can update the README.
