### PR TITLE
add cterm colors

### DIFF
--- a/lua/base16-colorscheme.lua
+++ b/lua/base16-colorscheme.lua
@@ -1,4 +1,5 @@
 -- Some useful links for making your own colorscheme:
+--
 -- https://github.com/chriskempson/base16
 -- https://colourco.de/
 -- https://color.adobe.com/create/color-wheel
@@ -853,46 +854,46 @@ function M.setup(colors, config)
         hi.DapUINormal = 'Normal'
         hi.DapUINormal    = "Normal"
         hi.DapUIVariable  = "Normal"
-        hi.DapUIScope     = { guifg = M.colors.base0D }
-        hi.DapUIType      = { guifg = M.colors.base0E }
+        hi.DapUIScope     = { guifg = M.colors.base0D, ctermfg = M.colors.cterm0D }
+        hi.DapUIType      = { guifg = M.colors.base0E, ctermfg = M.colors.cterm0E }
         hi.DapUIValue     = "Normal"
-        hi.DapUIModifiedValue = { gui = "bold", guifg = M.colors.base0D }
-        hi.DapUIDecoration = { guifg = M.colors.base0D }
-        hi.DapUIThread    = { guifg = M.colors.base0B }
-        hi.DapUIStoppedThread = { guifg = M.colors.base0D }
+        hi.DapUIModifiedValue = { gui = "bold", guifg = M.colors.base0D, ctermfg = M.colors.cterm0D }
+        hi.DapUIDecoration = { guifg = M.colors.base0D, ctermfg = M.colors.cterm0D }
+        hi.DapUIThread    = { guifg = M.colors.base0B, ctermfg = M.colors.cterm0B }
+        hi.DapUIStoppedThread = { guifg = M.colors.base0D, ctermfg = M.colors.cterm0D }
         hi.DapUIFrameName = "Normal"
-        hi.DapUISource    = { guifg = M.colors.base0E }
-        hi.DapUILineNumber = { guifg = M.colors.base0D }
+        hi.DapUISource    = { guifg = M.colors.base0E, ctermfg = M.colors.cterm0E }
+        hi.DapUILineNumber = { guifg = M.colors.base0D, ctermfg = M.colors.cterm0D }
         hi.DapUIFloatNormal = "NormalFloat"
-        hi.DapUIFloatBorder = { guifg = M.colors.base0D }
-        hi.DapUIWatchesEmpty = { guifg = M.colors.base08 }
-        hi.DapUIWatchesValue = { guifg = M.colors.base0B }
-        hi.DapUIWatchesError = { guifg = M.colors.base08 }
-        hi.DapUIBreakpointsPath = { guifg = M.colors.base0D }
-        hi.DapUIBreakpointsInfo = { guifg = M.colors.base0B }
-        hi.DapUIBreakpointsCurrentLine = { gui = "bold", guifg = M.colors.base0B }
+        hi.DapUIFloatBorder = { guifg = M.colors.base0D, ctermfg = M.colors.cterm0D }
+        hi.DapUIWatchesEmpty = { guifg = M.colors.base08, ctermfg = M.colors.cterm08 }
+        hi.DapUIWatchesValue = { guifg = M.colors.base0B, ctermfg = M.colors.cterm0B }
+        hi.DapUIWatchesError = { guifg = M.colors.base08, ctermfg = M.colors.cterm08 }
+        hi.DapUIBreakpointsPath = { guifg = M.colors.base0D, ctermfg = M.colors.cterm0D }
+        hi.DapUIBreakpointsInfo = { guifg = M.colors.base0B, ctermfg = M.colors.cterm0B }
+        hi.DapUIBreakpointsCurrentLine = { gui = "bold", guifg = M.colors.base0B, ctermfg = M.colors.cterm0B }
         hi.DapUIBreakpointsLine = "DapUILineNumber"
-        hi.DapUIBreakpointsDisabledLine = { guifg = M.colors.base02 }
+        hi.DapUIBreakpointsDisabledLine = { guifg = M.colors.base02, ctermfg = M.colors.cterm02 }
         hi.DapUICurrentFrameName = "DapUIBreakpointsCurrentLine"
-        hi.DapUIStepOver  = { guifg = M.colors.base0D }
-        hi.DapUIStepInto  = { guifg = M.colors.base0D }
-        hi.DapUIStepBack  = { guifg = M.colors.base0D }
-        hi.DapUIStepOut   = { guifg = M.colors.base0D }
-        hi.DapUIStop      = { guifg = M.colors.base08 }
-        hi.DapUIPlayPause = { guifg = M.colors.base0B }
-        hi.DapUIRestart   = { guifg = M.colors.base0B }
-        hi.DapUIUnavailable = { guifg = M.colors.base02 }
-        hi.DapUIWinSelect = { gui = "bold", guifg = M.colors.base0D }
+        hi.DapUIStepOver  = { guifg = M.colors.base0D, ctermfg = M.colors.cterm0D }
+        hi.DapUIStepInto  = { guifg = M.colors.base0D, ctermfg = M.colors.cterm0D }
+        hi.DapUIStepBack  = { guifg = M.colors.base0D, ctermfg = M.colors.cterm0D }
+        hi.DapUIStepOut   = { guifg = M.colors.base0D, ctermfg = M.colors.cterm0D }
+        hi.DapUIStop      = { guifg = M.colors.base08, ctermfg = M.colors.cterm08 }
+        hi.DapUIPlayPause = { guifg = M.colors.base0B, ctermfg = M.colors.cterm0B }
+        hi.DapUIRestart   = { guifg = M.colors.base0B, ctermfg = M.colors.cterm0B }
+        hi.DapUIUnavailable = { guifg = M.colors.base02, ctermfg = M.colors.cterm02 }
+        hi.DapUIWinSelect = { gui = "bold", guifg = M.colors.base0D, ctermfg = M.colors.cterm0D }
         hi.DapUIEndofBuffer = "EndOfBuffer"
         hi.DapUINormalNC  = "Normal"
-        hi.DapUIPlayPauseNC = { guifg = M.colors.base0B }
-        hi.DapUIRestartNC = { guifg = M.colors.base0B }
-        hi.DapUIStopNC    = { guifg = M.colors.base08 }
-        hi.DapUIUnavailableNC = { guifg = M.colors.base02 }
-        hi.DapUIStepOverNC = { guifg = M.colors.base0D }
-        hi.DapUIStepIntoNC = { guifg = M.colors.base0D }
-        hi.DapUIStepBackNC = { guifg = M.colors.base0D }
-        hi.DapUIStepOutNC = { guifg = M.colors.base0D }
+        hi.DapUIPlayPauseNC = { guifg = M.colors.base0B, ctermfg = M.colors.cterm0B }
+        hi.DapUIRestartNC = { guifg = M.colors.base0B, ctermfg = M.colors.cterm0B }
+        hi.DapUIStopNC    = { guifg = M.colors.base08, ctermfg = M.colors.cterm08 }
+        hi.DapUIUnavailableNC = { guifg = M.colors.base02, ctermfg = M.colors.cterm02 }
+        hi.DapUIStepOverNC = { guifg = M.colors.base0D, ctermfg = M.colors.cterm0D }
+        hi.DapUIStepIntoNC = { guifg = M.colors.base0D, ctermfg = M.colors.cterm0D }
+        hi.DapUIStepBackNC = { guifg = M.colors.base0D, ctermfg = M.colors.cterm0D }
+        hi.DapUIStepOutNC = { guifg = M.colors.base0D, ctermfg = M.colors.cterm0D }
     end
 
 

--- a/lua/base16-colorscheme.lua
+++ b/lua/base16-colorscheme.lua
@@ -144,7 +144,8 @@ function M.setup(colors, config)
     -- Vim editor colors
     hi.Normal                             = { guifg = M.colors.base05, guibg = M.colors.base00, gui = nil, guisp = nil,
                                               ctermfg = M.colors.cterm05, ctermbg = M.colors.cterm00 }
-    hi.Bold                               = { guifg = nil, guibg = nil, gui = 'bold', guisp = nil }
+    hi.Bold                               = { guifg = nil, guibg = nil, gui = 'bold', guisp = nil,
+                                              ctermfg = nil, ctermbg = nil }
     hi.Debug                              = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil,
                                               ctermfg = M.colors.cterm08, ctermbg = nil }
     hi.Directory                          = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil,

--- a/lua/base16-colorscheme.lua
+++ b/lua/base16-colorscheme.lua
@@ -144,252 +144,135 @@ function M.setup(colors, config)
     local hi                              = M.highlight
 
     -- Vim editor colors
-    hi.Normal                             = { guifg = M.colors.base05, guibg = M.colors.base00, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm05, ctermbg = M.colors.cterm00 }
-    hi.Bold                               = { guifg = nil, guibg = nil, gui = 'bold', guisp = nil,
-                                              ctermfg = nil, ctermbg = nil }
-    hi.Debug                              = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm08, ctermbg = nil }
-    hi.Directory                          = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm0D, ctermbg = nil }
-    hi.Error                              = { guifg = M.colors.base08, guibg = M.colors.base00, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm08, ctermbg = M.colors.cterm00 }
-    hi.ErrorMsg                           = { guifg = M.colors.base08, guibg = M.colors.base00, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm08, ctermbg = M.colors.cterm00 }
-    hi.Exception                          = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm08, ctermbg = nil }
-    hi.FoldColumn                         = { guifg = M.colors.base0C, guibg = M.colors.base00, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm0C, ctermbg = M.colors.cterm00 }
-    hi.Folded                             = { guifg = M.colors.base03, guibg = M.colors.base01, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm03, ctermbg = M.colors.cterm01 }
-    hi.IncSearch                          = { guifg = M.colors.base01, guibg = M.colors.base09, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm01, ctermbg = M.colors.cterm09 }
-    hi.Italic                             = { guifg = nil, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = nil, ctermbg = nil }
-    hi.Macro                              = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm08, ctermbg = nil }
-    hi.MatchParen                         = { guifg = nil, guibg = M.colors.base03, gui = nil, guisp = nil,
-                                              ctermfg = nil, ctermbg = M.colors.cterm03 }
-    hi.ModeMsg                            = { guifg = M.colors.base0B, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm0B, ctermbg = nil }
-    hi.MoreMsg                            = { guifg = M.colors.base0B, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm0B, ctermbg = nil }
-    hi.Question                           = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm0D, ctermbg = nil }
-    hi.Search                             = { guifg = M.colors.base01, guibg = M.colors.base0A, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm01, ctermbg = M.colors.cterm0A }
-    hi.Substitute                         = { guifg = M.colors.base01, guibg = M.colors.base0A, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm01, ctermbg = M.colors.cterm0A }
-    hi.SpecialKey                         = { guifg = M.colors.base03, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm03, ctermbg = nil }
-    hi.TooLong                            = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm08, ctermbg = nil }
-    hi.Underlined                         = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm08, ctermbg = nil }
-    hi.Visual                             = { guifg = nil, guibg = M.colors.base02, gui = nil, guisp = nil,
-                                              ctermfg = nil, ctermbg = M.colors.cterm02 }
-    hi.VisualNOS                          = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm08, ctermbg = nil }
-    hi.WarningMsg                         = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm08, ctermbg = nil }
-    hi.WildMenu                           = { guifg = M.colors.base08, guibg = M.colors.base0A, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm08, ctermbg = M.colors.cterm0A }
-    hi.Title                              = { guifg = M.colors.base0D, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm0D, ctermbg = nil }
-    hi.Conceal                            = { guifg = M.colors.base0D, guibg = M.colors.base00, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm0D, ctermbg = M.colors.cterm00 }
-    hi.Cursor                             = { guifg = M.colors.base00, guibg = M.colors.base05, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm00, ctermbg = M.colors.cterm05 }
-    hi.NonText                            = { guifg = M.colors.base03, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm03, ctermbg = nil }
-    hi.LineNr                             = { guifg = M.colors.base04, guibg = M.colors.base00, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm04, ctermbg = M.colors.cterm00 }
-    hi.SignColumn                         = { guifg = M.colors.base04, guibg = M.colors.base00, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm04, ctermbg = M.colors.cterm00 }
-    hi.StatusLine                         = { guifg = M.colors.base05, guibg = M.colors.base02, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm05, ctermbg = M.colors.cterm02 }
-    hi.StatusLineNC                       = { guifg = M.colors.base04, guibg = M.colors.base01, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm04, ctermbg = M.colors.cterm01 }
-    hi.WinBar                             = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm05, ctermbg = nil }
-    hi.WinBarNC                           = { guifg = M.colors.base04, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm04, ctermbg = nil }
-    hi.VertSplit                          = { guifg = M.colors.base05, guibg = M.colors.base00, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm05, ctermbg = M.colors.cterm00 }
-    hi.ColorColumn                        = { guifg = nil, guibg = M.colors.base01, gui = 'none', guisp = nil,
-                                              ctermfg = nil, ctermbg = M.colors.cterm01 }
-    hi.CursorColumn                       = { guifg = nil, guibg = M.colors.base01, gui = 'none', guisp = nil,
-                                              ctermfg = nil, ctermbg = M.colors.cterm01 }
-    hi.CursorLine                         = { guifg = nil, guibg = M.colors.base01, gui = 'none', guisp = nil,
-                                              ctermfg = nil, ctermbg = M.colors.cterm01 }
-    hi.CursorLineNr                       = { guifg = M.colors.base04, guibg = M.colors.base01, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm04, ctermbg = M.colors.cterm01 }
-    hi.QuickFixLine                       = { guifg = nil, guibg = M.colors.base01, gui = 'none', guisp = nil,
-                                              ctermfg = nil, ctermbg = M.colors.cterm01 }
-    hi.PMenu                              = { guifg = M.colors.base05, guibg = M.colors.base01, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm05, ctermbg = M.colors.cterm01 }
-    hi.PMenuSel                           = { guifg = M.colors.base01, guibg = M.colors.base05, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm01, ctermbg = M.colors.cterm05 }
-    hi.TabLine                            = { guifg = M.colors.base03, guibg = M.colors.base01, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm03, ctermbg = M.colors.cterm01 }
-    hi.TabLineFill                        = { guifg = M.colors.base03, guibg = M.colors.base01, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm03, ctermbg = M.colors.cterm01 }
-    hi.TabLineSel                         = { guifg = M.colors.base0B, guibg = M.colors.base01, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm0B, ctermbg = M.colors.cterm01 }
+    hi.Normal                             = { guifg = M.colors.base05, guibg = M.colors.base00, gui = nil, guisp = nil, ctermfg = M.colors.cterm05, ctermbg = M.colors.cterm00 }
+    hi.Bold                               = { guifg = nil, guibg = nil, gui = 'bold', guisp = nil, ctermfg = nil, ctermbg = nil }
+    hi.Debug                              = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm08, ctermbg = nil }
+    hi.Directory                          = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm0D, ctermbg = nil }
+    hi.Error                              = { guifg = M.colors.base08, guibg = M.colors.base00, gui = nil, guisp = nil, ctermfg = M.colors.cterm08, ctermbg = M.colors.cterm00 }
+    hi.ErrorMsg                           = { guifg = M.colors.base08, guibg = M.colors.base00, gui = nil, guisp = nil, ctermfg = M.colors.cterm08, ctermbg = M.colors.cterm00 }
+    hi.Exception                          = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm08, ctermbg = nil }
+    hi.FoldColumn                         = { guifg = M.colors.base0C, guibg = M.colors.base00, gui = nil, guisp = nil, ctermfg = M.colors.cterm0C, ctermbg = M.colors.cterm00 }
+    hi.Folded                             = { guifg = M.colors.base03, guibg = M.colors.base01, gui = nil, guisp = nil, ctermfg = M.colors.cterm03, ctermbg = M.colors.cterm01 }
+    hi.IncSearch                          = { guifg = M.colors.base01, guibg = M.colors.base09, gui = 'none', guisp = nil, ctermfg = M.colors.cterm01, ctermbg = M.colors.cterm09 }
+    hi.Italic                             = { guifg = nil, guibg = nil, gui = 'none', guisp = nil, ctermfg = nil, ctermbg = nil }
+    hi.Macro                              = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm08, ctermbg = nil }
+    hi.MatchParen                         = { guifg = nil, guibg = M.colors.base03, gui = nil, guisp = nil, ctermfg = nil, ctermbg = M.colors.cterm03 }
+    hi.ModeMsg                            = { guifg = M.colors.base0B, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm0B, ctermbg = nil }
+    hi.MoreMsg                            = { guifg = M.colors.base0B, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm0B, ctermbg = nil }
+    hi.Question                           = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm0D, ctermbg = nil }
+    hi.Search                             = { guifg = M.colors.base01, guibg = M.colors.base0A, gui = nil, guisp = nil, ctermfg = M.colors.cterm01, ctermbg = M.colors.cterm0A }
+    hi.Substitute                         = { guifg = M.colors.base01, guibg = M.colors.base0A, gui = 'none', guisp = nil, ctermfg = M.colors.cterm01, ctermbg = M.colors.cterm0A }
+    hi.SpecialKey                         = { guifg = M.colors.base03, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm03, ctermbg = nil }
+    hi.TooLong                            = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm08, ctermbg = nil }
+    hi.Underlined                         = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm08, ctermbg = nil }
+    hi.Visual                             = { guifg = nil, guibg = M.colors.base02, gui = nil, guisp = nil, ctermfg = nil, ctermbg = M.colors.cterm02 }
+    hi.VisualNOS                          = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm08, ctermbg = nil }
+    hi.WarningMsg                         = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm08, ctermbg = nil }
+    hi.WildMenu                           = { guifg = M.colors.base08, guibg = M.colors.base0A, gui = nil, guisp = nil, ctermfg = M.colors.cterm08, ctermbg = M.colors.cterm0A }
+    hi.Title                              = { guifg = M.colors.base0D, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm0D, ctermbg = nil }
+    hi.Conceal                            = { guifg = M.colors.base0D, guibg = M.colors.base00, gui = nil, guisp = nil, ctermfg = M.colors.cterm0D, ctermbg = M.colors.cterm00 }
+    hi.Cursor                             = { guifg = M.colors.base00, guibg = M.colors.base05, gui = nil, guisp = nil, ctermfg = M.colors.cterm00, ctermbg = M.colors.cterm05 }
+    hi.NonText                            = { guifg = M.colors.base03, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm03, ctermbg = nil }
+    hi.LineNr                             = { guifg = M.colors.base04, guibg = M.colors.base00, gui = nil, guisp = nil, ctermfg = M.colors.cterm04, ctermbg = M.colors.cterm00 }
+    hi.SignColumn                         = { guifg = M.colors.base04, guibg = M.colors.base00, gui = nil, guisp = nil, ctermfg = M.colors.cterm04, ctermbg = M.colors.cterm00 }
+    hi.StatusLine                         = { guifg = M.colors.base05, guibg = M.colors.base02, gui = 'none', guisp = nil, ctermfg = M.colors.cterm05, ctermbg = M.colors.cterm02 }
+    hi.StatusLineNC                       = { guifg = M.colors.base04, guibg = M.colors.base01, gui = 'none', guisp = nil, ctermfg = M.colors.cterm04, ctermbg = M.colors.cterm01 }
+    hi.WinBar                             = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm05, ctermbg = nil }
+    hi.WinBarNC                           = { guifg = M.colors.base04, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm04, ctermbg = nil }
+    hi.VertSplit                          = { guifg = M.colors.base05, guibg = M.colors.base00, gui = 'none', guisp = nil, ctermfg = M.colors.cterm05, ctermbg = M.colors.cterm00 }
+    hi.ColorColumn                        = { guifg = nil, guibg = M.colors.base01, gui = 'none', guisp = nil, ctermfg = nil, ctermbg = M.colors.cterm01 }
+    hi.CursorColumn                       = { guifg = nil, guibg = M.colors.base01, gui = 'none', guisp = nil, ctermfg = nil, ctermbg = M.colors.cterm01 }
+    hi.CursorLine                         = { guifg = nil, guibg = M.colors.base01, gui = 'none', guisp = nil, ctermfg = nil, ctermbg = M.colors.cterm01 }
+    hi.CursorLineNr                       = { guifg = M.colors.base04, guibg = M.colors.base01, gui = nil, guisp = nil, ctermfg = M.colors.cterm04, ctermbg = M.colors.cterm01 }
+    hi.QuickFixLine                       = { guifg = nil, guibg = M.colors.base01, gui = 'none', guisp = nil, ctermfg = nil, ctermbg = M.colors.cterm01 }
+    hi.PMenu                              = { guifg = M.colors.base05, guibg = M.colors.base01, gui = 'none', guisp = nil, ctermfg = M.colors.cterm05, ctermbg = M.colors.cterm01 }
+    hi.PMenuSel                           = { guifg = M.colors.base01, guibg = M.colors.base05, gui = nil, guisp = nil, ctermfg = M.colors.cterm01, ctermbg = M.colors.cterm05 }
+    hi.TabLine                            = { guifg = M.colors.base03, guibg = M.colors.base01, gui = 'none', guisp = nil, ctermfg = M.colors.cterm03, ctermbg = M.colors.cterm01 }
+    hi.TabLineFill                        = { guifg = M.colors.base03, guibg = M.colors.base01, gui = 'none', guisp = nil, ctermfg = M.colors.cterm03, ctermbg = M.colors.cterm01 }
+    hi.TabLineSel                         = { guifg = M.colors.base0B, guibg = M.colors.base01, gui = 'none', guisp = nil, ctermfg = M.colors.cterm0B, ctermbg = M.colors.cterm01 }
 
     -- Standard syntax highlighting
-    hi.Boolean                            = { guifg = M.colors.base09, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm09, ctermbg = nil }
-    hi.Character                          = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm08, ctermbg = nil }
-    hi.Comment                            = { guifg = M.colors.base03, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm03, ctermbg = nil }
-    hi.Conditional                        = { guifg = M.colors.base0E, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm0E, ctermbg = nil }
-    hi.Constant                           = { guifg = M.colors.base09, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm09, ctermbg = nil }
-    hi.Define                             = { guifg = M.colors.base0E, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm0E, ctermbg = nil }
-    hi.Delimiter                          = { guifg = M.colors.base0F, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm0F, ctermbg = nil }
-    hi.Float                              = { guifg = M.colors.base09, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm09, ctermbg = nil }
-    hi.Function                           = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm0D, ctermbg = nil }
-    hi.Identifier                         = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm08, ctermbg = nil }
-    hi.Include                            = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm0D, ctermbg = nil }
-    hi.Keyword                            = { guifg = M.colors.base0E, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm0E, ctermbg = nil }
-    hi.Label                              = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm0A, ctermbg = nil }
-    hi.Number                             = { guifg = M.colors.base09, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm09, ctermbg = nil }
-    hi.Operator                           = { guifg = M.colors.base0E, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm0E, ctermbg = nil }
-    hi.PreProc                            = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm0A, ctermbg = nil }
-    hi.Repeat                             = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm0A, ctermbg = nil }
-    hi.Special                            = { guifg = M.colors.base0C, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm0C, ctermbg = nil }
-    hi.SpecialChar                        = { guifg = M.colors.base0F, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm0F, ctermbg = nil }
-    hi.Statement                          = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm08, ctermbg = nil }
-    hi.StorageClass                       = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm0A, ctermbg = nil }
-    hi.String                             = { guifg = M.colors.base0B, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm0B, ctermbg = nil }
-    hi.Structure                          = { guifg = M.colors.base0E, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm0E, ctermbg = nil }
-    hi.Tag                                = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm0A, ctermbg = nil }
-    hi.Todo                               = { guifg = M.colors.base0A, guibg = M.colors.base01, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm0A, ctermbg = M.colors.cterm01 }
-    hi.Type                               = { guifg = M.colors.base0A, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm0A, ctermbg = nil }
-    hi.Typedef                            = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm0A, ctermbg = nil }
+    hi.Boolean                            = { guifg = M.colors.base09, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm09, ctermbg = nil }
+    hi.Character                          = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm08, ctermbg = nil }
+    hi.Comment                            = { guifg = M.colors.base03, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm03, ctermbg = nil }
+    hi.Conditional                        = { guifg = M.colors.base0E, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm0E, ctermbg = nil }
+    hi.Constant                           = { guifg = M.colors.base09, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm09, ctermbg = nil }
+    hi.Define                             = { guifg = M.colors.base0E, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm0E, ctermbg = nil }
+    hi.Delimiter                          = { guifg = M.colors.base0F, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm0F, ctermbg = nil }
+    hi.Float                              = { guifg = M.colors.base09, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm09, ctermbg = nil }
+    hi.Function                           = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm0D, ctermbg = nil }
+    hi.Identifier                         = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm08, ctermbg = nil }
+    hi.Include                            = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm0D, ctermbg = nil }
+    hi.Keyword                            = { guifg = M.colors.base0E, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm0E, ctermbg = nil }
+    hi.Label                              = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm0A, ctermbg = nil }
+    hi.Number                             = { guifg = M.colors.base09, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm09, ctermbg = nil }
+    hi.Operator                           = { guifg = M.colors.base0E, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm0E, ctermbg = nil }
+    hi.PreProc                            = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm0A, ctermbg = nil }
+    hi.Repeat                             = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm0A, ctermbg = nil }
+    hi.Special                            = { guifg = M.colors.base0C, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm0C, ctermbg = nil }
+    hi.SpecialChar                        = { guifg = M.colors.base0F, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm0F, ctermbg = nil }
+    hi.Statement                          = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm08, ctermbg = nil }
+    hi.StorageClass                       = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm0A, ctermbg = nil }
+    hi.String                             = { guifg = M.colors.base0B, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm0B, ctermbg = nil }
+    hi.Structure                          = { guifg = M.colors.base0E, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm0E, ctermbg = nil }
+    hi.Tag                                = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm0A, ctermbg = nil }
+    hi.Todo                               = { guifg = M.colors.base0A, guibg = M.colors.base01, gui = nil, guisp = nil, ctermfg = M.colors.cterm0A, ctermbg = M.colors.cterm01 }
+    hi.Type                               = { guifg = M.colors.base0A, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm0A, ctermbg = nil }
+    hi.Typedef                            = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm0A, ctermbg = nil }
 
     -- Diff highlighting
-    hi.DiffAdd                            = { guifg = M.colors.base0B, guibg = M.colors.base00, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm0B, ctermbg = M.colors.cterm00 }
-    hi.DiffChange                         = { guifg = M.colors.base03, guibg = M.colors.base00, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm03, ctermbg = M.colors.cterm00 }
-    hi.DiffDelete                         = { guifg = M.colors.base08, guibg = M.colors.base00, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm08, ctermbg = M.colors.cterm00 }
-    hi.DiffText                           = { guifg = M.colors.base0D, guibg = M.colors.base00, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm0D, ctermbg = M.colors.cterm00 }
-    hi.DiffAdded                          = { guifg = M.colors.base0B, guibg = M.colors.base00, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm0B, ctermbg = M.colors.cterm00 }
-    hi.DiffFile                           = { guifg = M.colors.base08, guibg = M.colors.base00, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm08, ctermbg = M.colors.cterm00 }
-    hi.DiffNewFile                        = { guifg = M.colors.base0B, guibg = M.colors.base00, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm0B, ctermbg = M.colors.cterm00 }
-    hi.DiffLine                           = { guifg = M.colors.base0D, guibg = M.colors.base00, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm0D, ctermbg = M.colors.cterm00 }
-    hi.DiffRemoved                        = { guifg = M.colors.base08, guibg = M.colors.base00, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm08, ctermbg = M.colors.cterm00 }
+    hi.DiffAdd                            = { guifg = M.colors.base0B, guibg = M.colors.base00, gui = nil, guisp = nil, ctermfg = M.colors.cterm0B, ctermbg = M.colors.cterm00 }
+    hi.DiffChange                         = { guifg = M.colors.base03, guibg = M.colors.base00, gui = nil, guisp = nil, ctermfg = M.colors.cterm03, ctermbg = M.colors.cterm00 }
+    hi.DiffDelete                         = { guifg = M.colors.base08, guibg = M.colors.base00, gui = nil, guisp = nil, ctermfg = M.colors.cterm08, ctermbg = M.colors.cterm00 }
+    hi.DiffText                           = { guifg = M.colors.base0D, guibg = M.colors.base00, gui = nil, guisp = nil, ctermfg = M.colors.cterm0D, ctermbg = M.colors.cterm00 }
+    hi.DiffAdded                          = { guifg = M.colors.base0B, guibg = M.colors.base00, gui = nil, guisp = nil, ctermfg = M.colors.cterm0B, ctermbg = M.colors.cterm00 }
+    hi.DiffFile                           = { guifg = M.colors.base08, guibg = M.colors.base00, gui = nil, guisp = nil, ctermfg = M.colors.cterm08, ctermbg = M.colors.cterm00 }
+    hi.DiffNewFile                        = { guifg = M.colors.base0B, guibg = M.colors.base00, gui = nil, guisp = nil, ctermfg = M.colors.cterm0B, ctermbg = M.colors.cterm00 }
+    hi.DiffLine                           = { guifg = M.colors.base0D, guibg = M.colors.base00, gui = nil, guisp = nil, ctermfg = M.colors.cterm0D, ctermbg = M.colors.cterm00 }
+    hi.DiffRemoved                        = { guifg = M.colors.base08, guibg = M.colors.base00, gui = nil, guisp = nil, ctermfg = M.colors.cterm08, ctermbg = M.colors.cterm00 }
 
     -- Git highlighting
-    hi.gitcommitOverflow                  = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm08, ctermbg = nil }
-    hi.gitcommitSummary                   = { guifg = M.colors.base0B, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm0B, ctermbg = nil }
-    hi.gitcommitComment                   = { guifg = M.colors.base03, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm03, ctermbg = nil }
-    hi.gitcommitUntracked                 = { guifg = M.colors.base03, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm03, ctermbg = nil }
-    hi.gitcommitDiscarded                 = { guifg = M.colors.base03, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm03, ctermbg = nil }
-    hi.gitcommitSelected                  = { guifg = M.colors.base03, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm03, ctermbg = nil }
-    hi.gitcommitHeader                    = { guifg = M.colors.base0E, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm0E, ctermbg = nil }
-    hi.gitcommitSelectedType              = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm0D, ctermbg = nil }
-    hi.gitcommitUnmergedType              = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm0D, ctermbg = nil }
-    hi.gitcommitDiscardedType             = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm0D, ctermbg = nil }
-    hi.gitcommitBranch                    = { guifg = M.colors.base09, guibg = nil, gui = 'bold', guisp = nil,
-                                              ctermfg = M.colors.cterm09, ctermbg = nil }
-    hi.gitcommitUntrackedFile             = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm0A, ctermbg = nil }
-    hi.gitcommitUnmergedFile              = { guifg = M.colors.base08, guibg = nil, gui = 'bold', guisp = nil,
-                                              ctermfg = M.colors.cterm08, ctermbg = nil }
-    hi.gitcommitDiscardedFile             = { guifg = M.colors.base08, guibg = nil, gui = 'bold', guisp = nil,
-                                              ctermfg = M.colors.cterm08, ctermbg = nil }
-    hi.gitcommitSelectedFile              = { guifg = M.colors.base0B, guibg = nil, gui = 'bold', guisp = nil,
-                                              ctermfg = M.colors.cterm0B, ctermbg = nil }
+    hi.gitcommitOverflow                  = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm08, ctermbg = nil }
+    hi.gitcommitSummary                   = { guifg = M.colors.base0B, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm0B, ctermbg = nil }
+    hi.gitcommitComment                   = { guifg = M.colors.base03, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm03, ctermbg = nil }
+    hi.gitcommitUntracked                 = { guifg = M.colors.base03, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm03, ctermbg = nil }
+    hi.gitcommitDiscarded                 = { guifg = M.colors.base03, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm03, ctermbg = nil }
+    hi.gitcommitSelected                  = { guifg = M.colors.base03, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm03, ctermbg = nil }
+    hi.gitcommitHeader                    = { guifg = M.colors.base0E, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm0E, ctermbg = nil }
+    hi.gitcommitSelectedType              = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm0D, ctermbg = nil }
+    hi.gitcommitUnmergedType              = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm0D, ctermbg = nil }
+    hi.gitcommitDiscardedType             = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm0D, ctermbg = nil }
+    hi.gitcommitBranch                    = { guifg = M.colors.base09, guibg = nil, gui = 'bold', guisp = nil, ctermfg = M.colors.cterm09, ctermbg = nil }
+    hi.gitcommitUntrackedFile             = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm0A, ctermbg = nil }
+    hi.gitcommitUnmergedFile              = { guifg = M.colors.base08, guibg = nil, gui = 'bold', guisp = nil, ctermfg = M.colors.cterm08, ctermbg = nil }
+    hi.gitcommitDiscardedFile             = { guifg = M.colors.base08, guibg = nil, gui = 'bold', guisp = nil, ctermfg = M.colors.cterm08, ctermbg = nil }
+    hi.gitcommitSelectedFile              = { guifg = M.colors.base0B, guibg = nil, gui = 'bold', guisp = nil, ctermfg = M.colors.cterm0B, ctermbg = nil }
 
     -- GitGutter highlighting
-    hi.GitGutterAdd                       = { guifg = M.colors.base0B, guibg = M.colors.base00, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm0B, ctermbg = M.colors.cterm00 }
-    hi.GitGutterChange                    = { guifg = M.colors.base0D, guibg = M.colors.base00, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm0D, ctermbg = M.colors.cterm00 }
-    hi.GitGutterDelete                    = { guifg = M.colors.base08, guibg = M.colors.base00, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm08, ctermbg = M.colors.cterm00 }
-    hi.GitGutterChangeDelete              = { guifg = M.colors.base0E, guibg = M.colors.base00, gui = nil, guisp = nil,
-                                              ctermfg = M.colors.cterm0E, ctermbg = M.colors.cterm00 }
+    hi.GitGutterAdd                       = { guifg = M.colors.base0B, guibg = M.colors.base00, gui = nil, guisp = nil, ctermfg = M.colors.cterm0B, ctermbg = M.colors.cterm00 }
+    hi.GitGutterChange                    = { guifg = M.colors.base0D, guibg = M.colors.base00, gui = nil, guisp = nil, ctermfg = M.colors.cterm0D, ctermbg = M.colors.cterm00 }
+    hi.GitGutterDelete                    = { guifg = M.colors.base08, guibg = M.colors.base00, gui = nil, guisp = nil, ctermfg = M.colors.cterm08, ctermbg = M.colors.cterm00 }
+    hi.GitGutterChangeDelete              = { guifg = M.colors.base0E, guibg = M.colors.base00, gui = nil, guisp = nil, ctermfg = M.colors.cterm0E, ctermbg = M.colors.cterm00 }
 
     -- Spelling highlighting
-    hi.SpellBad                           = { guifg = nil, guibg = nil, gui = 'undercurl', guisp = M.colors.base08,
-                                              ctermfg = nil, ctermbg = nil }
-    hi.SpellLocal                         = { guifg = nil, guibg = nil, gui = 'undercurl', guisp = M.colors.base0C,
-                                              ctermfg = nil, ctermbg = nil }
-    hi.SpellCap                           = { guifg = nil, guibg = nil, gui = 'undercurl', guisp = M.colors.base0D,
-                                              ctermfg = nil, ctermbg = nil }
-    hi.SpellRare                          = { guifg = nil, guibg = nil, gui = 'undercurl', guisp = M.colors.base0E,
-                                              ctermfg = nil, ctermbg = nil }
+    hi.SpellBad                           = { guifg = nil, guibg = nil, gui = 'undercurl', guisp = M.colors.base08, ctermfg = nil, ctermbg = nil }
+    hi.SpellLocal                         = { guifg = nil, guibg = nil, gui = 'undercurl', guisp = M.colors.base0C, ctermfg = nil, ctermbg = nil }
+    hi.SpellCap                           = { guifg = nil, guibg = nil, gui = 'undercurl', guisp = M.colors.base0D, ctermfg = nil, ctermbg = nil }
+    hi.SpellRare                          = { guifg = nil, guibg = nil, gui = 'undercurl', guisp = M.colors.base0E, ctermfg = nil, ctermbg = nil }
 
-    hi.DiagnosticError                    = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm08, ctermbg = nil }
-    hi.DiagnosticWarn                     = { guifg = M.colors.base0E, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm0E, ctermbg = nil }
-    hi.DiagnosticInfo                     = { guifg = M.colors.base0D, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm0D, ctermbg = nil }
-    hi.DiagnosticHint                     = { guifg = M.colors.base0C, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm0C, ctermbg = nil }
-    hi.DiagnosticUnderlineError           = { guifg = nil, guibg = nil, gui = 'undercurl', guisp = M.colors.base08,
-                                              ctermfg = nil, ctermbg = nil }
-    hi.DiagnosticUnderlineWarning         = { guifg = nil, guibg = nil, gui = 'undercurl', guisp = M.colors.base0E,
-                                              ctermfg = nil, ctermbg = nil }
-    hi.DiagnosticUnderlineWarn            = { guifg = nil, guibg = nil, gui = 'undercurl', guisp = M.colors.base0E,
-                                              ctermfg = nil, ctermbg = nil }
-    hi.DiagnosticUnderlineInformation     = { guifg = nil, guibg = nil, gui = 'undercurl', guisp = M.colors.base0F,
-                                              ctermfg = nil, ctermbg = nil }
-    hi.DiagnosticUnderlineHint            = { guifg = nil, guibg = nil, gui = 'undercurl', guisp = M.colors.base0C,
-                                              ctermfg = nil, ctermbg = nil }
+    hi.DiagnosticError                    = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm08, ctermbg = nil }
+    hi.DiagnosticWarn                     = { guifg = M.colors.base0E, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm0E, ctermbg = nil }
+    hi.DiagnosticInfo                     = { guifg = M.colors.base0D, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm0D, ctermbg = nil }
+    hi.DiagnosticHint                     = { guifg = M.colors.base0C, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm0C, ctermbg = nil }
+    hi.DiagnosticUnderlineError           = { guifg = nil, guibg = nil, gui = 'undercurl', guisp = M.colors.base08, ctermfg = nil, ctermbg = nil }
+    hi.DiagnosticUnderlineWarning         = { guifg = nil, guibg = nil, gui = 'undercurl', guisp = M.colors.base0E, ctermfg = nil, ctermbg = nil }
+    hi.DiagnosticUnderlineWarn            = { guifg = nil, guibg = nil, gui = 'undercurl', guisp = M.colors.base0E, ctermfg = nil, ctermbg = nil }
+    hi.DiagnosticUnderlineInformation     = { guifg = nil, guibg = nil, gui = 'undercurl', guisp = M.colors.base0F, ctermfg = nil, ctermbg = nil }
+    hi.DiagnosticUnderlineHint            = { guifg = nil, guibg = nil, gui = 'undercurl', guisp = M.colors.base0C, ctermfg = nil, ctermbg = nil }
 
-    hi.LspReferenceText                   = { guifg = nil, guibg = nil, gui = 'underline', guisp = M.colors.base04,
-                                              ctermfg = nil, ctermbg = nil }
-    hi.LspReferenceRead                   = { guifg = nil, guibg = nil, gui = 'underline', guisp = M.colors.base04,
-                                              ctermfg = nil, ctermbg = nil }
-    hi.LspReferenceWrite                  = { guifg = nil, guibg = nil, gui = 'underline', guisp = M.colors.base04,
-                                              ctermfg = nil, ctermbg = nil }
+    hi.LspReferenceText                   = { guifg = nil, guibg = nil, gui = 'underline', guisp = M.colors.base04, ctermfg = nil, ctermbg = nil }
+    hi.LspReferenceRead                   = { guifg = nil, guibg = nil, gui = 'underline', guisp = M.colors.base04, ctermfg = nil, ctermbg = nil }
+    hi.LspReferenceWrite                  = { guifg = nil, guibg = nil, gui = 'underline', guisp = M.colors.base04, ctermfg = nil, ctermbg = nil }
     hi.LspDiagnosticsDefaultError         = 'DiagnosticError'
     hi.LspDiagnosticsDefaultWarning       = 'DiagnosticWarn'
     hi.LspDiagnosticsDefaultInformation   = 'DiagnosticInfo'
@@ -399,120 +282,64 @@ function M.setup(colors, config)
     hi.LspDiagnosticsUnderlineInformation = 'DiagnosticUnderlineInformation'
     hi.LspDiagnosticsUnderlineHint        = 'DiagnosticUnderlineHint'
 
-    hi.TSAnnotation                       = { guifg = M.colors.base0F, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm0F, ctermbg = nil }
-    hi.TSAttribute                        = { guifg = M.colors.base0A, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm0A, ctermbg = nil }
-    hi.TSBoolean                          = { guifg = M.colors.base09, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm09, ctermbg = nil }
-    hi.TSCharacter                        = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm08, ctermbg = nil }
-    hi.TSComment                          = { guifg = M.colors.base03, guibg = nil, gui = 'italic', guisp = nil,
-                                              ctermfg = M.colors.cterm03, ctermbg = nil }
-    hi.TSConstructor                      = { guifg = M.colors.base0D, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm0D, ctermbg = nil }
-    hi.TSConditional                      = { guifg = M.colors.base0E, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm0E, ctermbg = nil }
-    hi.TSConstant                         = { guifg = M.colors.base09, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm09, ctermbg = nil }
-    hi.TSConstBuiltin                     = { guifg = M.colors.base09, guibg = nil, gui = 'italic', guisp = nil,
-                                              ctermfg = M.colors.cterm09, ctermbg = nil }
-    hi.TSConstMacro                       = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm08, ctermbg = nil }
-    hi.TSError                            = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm08, ctermbg = nil }
-    hi.TSException                        = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm08, ctermbg = nil }
-    hi.TSField                            = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm05, ctermbg = nil }
-    hi.TSFloat                            = { guifg = M.colors.base09, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm09, ctermbg = nil }
-    hi.TSFunction                         = { guifg = M.colors.base0D, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm0D, ctermbg = nil }
-    hi.TSFuncBuiltin                      = { guifg = M.colors.base0D, guibg = nil, gui = 'italic', guisp = nil,
-                                              ctermfg = M.colors.cterm0D, ctermbg = nil }
-    hi.TSFuncMacro                        = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm08, ctermbg = nil }
-    hi.TSInclude                          = { guifg = M.colors.base0D, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm0D, ctermbg = nil }
-    hi.TSKeyword                          = { guifg = M.colors.base0E, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm0E, ctermbg = nil }
-    hi.TSKeywordFunction                  = { guifg = M.colors.base0E, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm0E, ctermbg = nil }
-    hi.TSKeywordOperator                  = { guifg = M.colors.base0E, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm0E, ctermbg = nil }
-    hi.TSLabel                            = { guifg = M.colors.base0A, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm0A, ctermbg = nil }
-    hi.TSMethod                           = { guifg = M.colors.base0D, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm0D, ctermbg = nil }
-    hi.TSNamespace                        = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm08, ctermbg = nil }
-    hi.TSNone                             = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm05, ctermbg = nil }
-    hi.TSNumber                           = { guifg = M.colors.base09, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm09, ctermbg = nil }
-    hi.TSOperator                         = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm05, ctermbg = nil }
-    hi.TSParameter                        = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm05, ctermbg = nil }
-    hi.TSParameterReference               = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm05, ctermbg = nil }
-    hi.TSProperty                         = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm05, ctermbg = nil }
-    hi.TSPunctDelimiter                   = { guifg = M.colors.base0F, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm0F, ctermbg = nil }
-    hi.TSPunctBracket                     = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm05, ctermbg = nil }
-    hi.TSPunctSpecial                     = { guifg = M.colors.base0F, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm0F, ctermbg = nil }
-    hi.TSRepeat                           = { guifg = M.colors.base0E, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm0E, ctermbg = nil }
-    hi.TSString                           = { guifg = M.colors.base0B, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm0B, ctermbg = nil }
-    hi.TSStringRegex                      = { guifg = M.colors.base0C, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm0C, ctermbg = nil }
-    hi.TSStringEscape                     = { guifg = M.colors.base0C, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm0C, ctermbg = nil }
-    hi.TSSymbol                           = { guifg = M.colors.base0B, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm0B, ctermbg = nil }
-    hi.TSTag                              = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm08, ctermbg = nil }
-    hi.TSTagDelimiter                     = { guifg = M.colors.base0F, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm0F, ctermbg = nil }
-    hi.TSText                             = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm05, ctermbg = nil }
-    hi.TSStrong                           = { guifg = nil, guibg = nil, gui = 'bold', guisp = nil,
-                                              ctermfg = nil, ctermbg = nil }
-    hi.TSEmphasis                         = { guifg = M.colors.base09, guibg = nil, gui = 'italic', guisp = nil,
-                                              ctermfg = M.colors.cterm09, ctermbg = nil }
-    hi.TSUnderline                        = { guifg = M.colors.base00, guibg = nil, gui = 'underline', guisp = nil,
-                                              ctermfg = M.colors.cterm00, ctermbg = nil }
-    hi.TSStrike                           = { guifg = M.colors.base00, guibg = nil, gui = 'strikethrough', guisp = nil,
-                                              ctermfg = M.colors.cterm00, ctermbg = nil }
-    hi.TSTitle                            = { guifg = M.colors.base0D, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm0D, ctermbg = nil }
-    hi.TSLiteral                          = { guifg = M.colors.base09, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm09, ctermbg = nil }
-    hi.TSURI                              = { guifg = M.colors.base09, guibg = nil, gui = 'underline', guisp = nil,
-                                              ctermfg = M.colors.cterm09, ctermbg = nil }
-    hi.TSType                             = { guifg = M.colors.base0A, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm0A, ctermbg = nil }
-    hi.TSTypeBuiltin                      = { guifg = M.colors.base0A, guibg = nil, gui = 'italic', guisp = nil,
-                                              ctermfg = M.colors.cterm0A, ctermbg = nil }
-    hi.TSVariable                         = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil,
-                                              ctermfg = M.colors.cterm08, ctermbg = nil }
-    hi.TSVariableBuiltin                  = { guifg = M.colors.base08, guibg = nil, gui = 'italic', guisp = nil,
-                                              ctermfg = M.colors.cterm08, ctermbg = nil }
+    hi.TSAnnotation                       = { guifg = M.colors.base0F, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm0F, ctermbg = nil }
+    hi.TSAttribute                        = { guifg = M.colors.base0A, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm0A, ctermbg = nil }
+    hi.TSBoolean                          = { guifg = M.colors.base09, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm09, ctermbg = nil }
+    hi.TSCharacter                        = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm08, ctermbg = nil }
+    hi.TSComment                          = { guifg = M.colors.base03, guibg = nil, gui = 'italic', guisp = nil, ctermfg = M.colors.cterm03, ctermbg = nil }
+    hi.TSConstructor                      = { guifg = M.colors.base0D, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm0D, ctermbg = nil }
+    hi.TSConditional                      = { guifg = M.colors.base0E, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm0E, ctermbg = nil }
+    hi.TSConstant                         = { guifg = M.colors.base09, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm09, ctermbg = nil }
+    hi.TSConstBuiltin                     = { guifg = M.colors.base09, guibg = nil, gui = 'italic', guisp = nil, ctermfg = M.colors.cterm09, ctermbg = nil }
+    hi.TSConstMacro                       = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm08, ctermbg = nil }
+    hi.TSError                            = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm08, ctermbg = nil }
+    hi.TSException                        = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm08, ctermbg = nil }
+    hi.TSField                            = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm05, ctermbg = nil }
+    hi.TSFloat                            = { guifg = M.colors.base09, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm09, ctermbg = nil }
+    hi.TSFunction                         = { guifg = M.colors.base0D, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm0D, ctermbg = nil }
+    hi.TSFuncBuiltin                      = { guifg = M.colors.base0D, guibg = nil, gui = 'italic', guisp = nil, ctermfg = M.colors.cterm0D, ctermbg = nil }
+    hi.TSFuncMacro                        = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm08, ctermbg = nil }
+    hi.TSInclude                          = { guifg = M.colors.base0D, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm0D, ctermbg = nil }
+    hi.TSKeyword                          = { guifg = M.colors.base0E, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm0E, ctermbg = nil }
+    hi.TSKeywordFunction                  = { guifg = M.colors.base0E, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm0E, ctermbg = nil }
+    hi.TSKeywordOperator                  = { guifg = M.colors.base0E, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm0E, ctermbg = nil }
+    hi.TSLabel                            = { guifg = M.colors.base0A, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm0A, ctermbg = nil }
+    hi.TSMethod                           = { guifg = M.colors.base0D, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm0D, ctermbg = nil }
+    hi.TSNamespace                        = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm08, ctermbg = nil }
+    hi.TSNone                             = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm05, ctermbg = nil }
+    hi.TSNumber                           = { guifg = M.colors.base09, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm09, ctermbg = nil }
+    hi.TSOperator                         = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm05, ctermbg = nil }
+    hi.TSParameter                        = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm05, ctermbg = nil }
+    hi.TSParameterReference               = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm05, ctermbg = nil }
+    hi.TSProperty                         = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm05, ctermbg = nil }
+    hi.TSPunctDelimiter                   = { guifg = M.colors.base0F, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm0F, ctermbg = nil }
+    hi.TSPunctBracket                     = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm05, ctermbg = nil }
+    hi.TSPunctSpecial                     = { guifg = M.colors.base0F, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm0F, ctermbg = nil }
+    hi.TSRepeat                           = { guifg = M.colors.base0E, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm0E, ctermbg = nil }
+    hi.TSString                           = { guifg = M.colors.base0B, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm0B, ctermbg = nil }
+    hi.TSStringRegex                      = { guifg = M.colors.base0C, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm0C, ctermbg = nil }
+    hi.TSStringEscape                     = { guifg = M.colors.base0C, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm0C, ctermbg = nil }
+    hi.TSSymbol                           = { guifg = M.colors.base0B, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm0B, ctermbg = nil }
+    hi.TSTag                              = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm08, ctermbg = nil }
+    hi.TSTagDelimiter                     = { guifg = M.colors.base0F, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm0F, ctermbg = nil }
+    hi.TSText                             = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm05, ctermbg = nil }
+    hi.TSStrong                           = { guifg = nil, guibg = nil, gui = 'bold', guisp = nil, ctermfg = nil, ctermbg = nil }
+    hi.TSEmphasis                         = { guifg = M.colors.base09, guibg = nil, gui = 'italic', guisp = nil, ctermfg = M.colors.cterm09, ctermbg = nil }
+    hi.TSUnderline                        = { guifg = M.colors.base00, guibg = nil, gui = 'underline', guisp = nil, ctermfg = M.colors.cterm00, ctermbg = nil }
+    hi.TSStrike                           = { guifg = M.colors.base00, guibg = nil, gui = 'strikethrough', guisp = nil, ctermfg = M.colors.cterm00, ctermbg = nil }
+    hi.TSTitle                            = { guifg = M.colors.base0D, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm0D, ctermbg = nil }
+    hi.TSLiteral                          = { guifg = M.colors.base09, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm09, ctermbg = nil }
+    hi.TSURI                              = { guifg = M.colors.base09, guibg = nil, gui = 'underline', guisp = nil, ctermfg = M.colors.cterm09, ctermbg = nil }
+    hi.TSType                             = { guifg = M.colors.base0A, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm0A, ctermbg = nil }
+    hi.TSTypeBuiltin                      = { guifg = M.colors.base0A, guibg = nil, gui = 'italic', guisp = nil, ctermfg = M.colors.cterm0A, ctermbg = nil }
+    hi.TSVariable                         = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm08, ctermbg = nil }
+    hi.TSVariableBuiltin                  = { guifg = M.colors.base08, guibg = nil, gui = 'italic', guisp = nil, ctermfg = M.colors.cterm08, ctermbg = nil }
 
-    hi.TSDefinition                       = { guifg = nil, guibg = nil, gui = 'underline', guisp = M.colors.base04,
-                                              ctermfg = nil, ctermbg = nil }
-    hi.TSDefinitionUsage                  = { guifg = nil, guibg = nil, gui = 'underline', guisp = M.colors.base04,
-                                              ctermfg = nil, ctermbg = nil }
-    hi.TSCurrentScope                     = { guifg = nil, guibg = nil, gui = 'bold', guisp = nil,
-                                              ctermfg = nil, ctermbg = nil }
+    hi.TSDefinition                       = { guifg = nil, guibg = nil, gui = 'underline', guisp = M.colors.base04, ctermfg = nil, ctermbg = nil }
+    hi.TSDefinitionUsage                  = { guifg = nil, guibg = nil, gui = 'underline', guisp = M.colors.base04, ctermfg = nil, ctermbg = nil }
+    hi.TSCurrentScope                     = { guifg = nil, guibg = nil, gui = 'bold', guisp = nil, ctermfg = nil, ctermbg = nil }
 
-    hi.LspInlayHint                       = { guifg = M.colors.base03, guibg = nil, gui = 'italic', guisp = nil,
-                                              ctermfg = M.colors.cterm03, ctermbg = nil }
+    hi.LspInlayHint                       = { guifg = M.colors.base03, guibg = nil, gui = 'italic', guisp = nil, ctermfg = M.colors.cterm03, ctermbg = nil }
 
     if vim.fn.has('nvim-0.8.0') then
         hi['@comment']                  = 'TSComment'
@@ -635,41 +462,25 @@ function M.setup(colors, config)
         hi.rainbowcol7 = { guifg = M.colors.base0E, ctermfg = M.colors.cterm0E  }
     end
 
-    hi.NvimInternalError = { guifg = M.colors.base00, guibg = M.colors.base08, gui = 'none', guisp = nil,
-                             ctermfg = M.colors.cterm00, ctermbg = M.colors.cterm08 }
+    hi.NvimInternalError = { guifg = M.colors.base00, guibg = M.colors.base08, gui = 'none', guisp = nil, ctermfg = M.colors.cterm00, ctermbg = M.colors.cterm08 }
 
-    hi.NormalFloat       = { guifg = M.colors.base05, guibg = M.colors.base00, gui = nil, guisp = nil,
-                             ctermfg = M.colors.cterm05, ctermbg = M.colors.cterm00 }
-    hi.FloatBorder       = { guifg = M.colors.base05, guibg = M.colors.base00, gui = nil, guisp = nil,
-                             ctermfg = M.colors.cterm05, ctermbg = M.colors.cterm00 }
-    hi.NormalNC          = { guifg = M.colors.base05, guibg = M.colors.base00, gui = nil, guisp = nil,
-                             ctermfg = M.colors.cterm05, ctermbg = M.colors.cterm00 }
-    hi.TermCursor        = { guifg = M.colors.base00, guibg = M.colors.base05, gui = 'none', guisp = nil,
-                             ctermfg = M.colors.cterm00, ctermbg = M.colors.cterm05 }
-    hi.TermCursorNC      = { guifg = M.colors.base00, guibg = M.colors.base05, gui = nil, guisp = nil,
-                             ctermfg = M.colors.cterm00, ctermbg = M.colors.cterm05 }
+    hi.NormalFloat       = { guifg = M.colors.base05, guibg = M.colors.base00, gui = nil, guisp = nil, ctermfg = M.colors.cterm05, ctermbg = M.colors.cterm00 }
+    hi.FloatBorder       = { guifg = M.colors.base05, guibg = M.colors.base00, gui = nil, guisp = nil, ctermfg = M.colors.cterm05, ctermbg = M.colors.cterm00 }
+    hi.NormalNC          = { guifg = M.colors.base05, guibg = M.colors.base00, gui = nil, guisp = nil, ctermfg = M.colors.cterm05, ctermbg = M.colors.cterm00 }
+    hi.TermCursor        = { guifg = M.colors.base00, guibg = M.colors.base05, gui = 'none', guisp = nil, ctermfg = M.colors.cterm00, ctermbg = M.colors.cterm05 }
+    hi.TermCursorNC      = { guifg = M.colors.base00, guibg = M.colors.base05, gui = nil, guisp = nil, ctermfg = M.colors.cterm00, ctermbg = M.colors.cterm05 }
 
-    hi.User1             = { guifg = M.colors.base08, guibg = M.colors.base02, gui = 'none', guisp = nil,
-                             ctermfg = M.colors.cterm08, ctermbg = M.colors.cterm02 }
-    hi.User2             = { guifg = M.colors.base0E, guibg = M.colors.base02, gui = 'none', guisp = nil,
-                             ctermfg = M.colors.cterm0E, ctermbg = M.colors.cterm02 }
-    hi.User3             = { guifg = M.colors.base05, guibg = M.colors.base02, gui = 'none', guisp = nil,
-                             ctermfg = M.colors.cterm05, ctermbg = M.colors.cterm02 }
-    hi.User4             = { guifg = M.colors.base0C, guibg = M.colors.base02, gui = 'none', guisp = nil,
-                             ctermfg = M.colors.cterm0C, ctermbg = M.colors.cterm02 }
-    hi.User5             = { guifg = M.colors.base05, guibg = M.colors.base02, gui = 'none', guisp = nil,
-                             ctermfg = M.colors.cterm05, ctermbg = M.colors.cterm02 }
-    hi.User6             = { guifg = M.colors.base05, guibg = M.colors.base01, gui = 'none', guisp = nil,
-                             ctermfg = M.colors.cterm05, ctermbg = M.colors.cterm01 }
-    hi.User7             = { guifg = M.colors.base05, guibg = M.colors.base02, gui = 'none', guisp = nil,
-                             ctermfg = M.colors.cterm05, ctermbg = M.colors.cterm02 }
-    hi.User8             = { guifg = M.colors.base00, guibg = M.colors.base02, gui = 'none', guisp = nil,
-                             ctermfg = M.colors.cterm00, ctermbg = M.colors.cterm02 }
-    hi.User9             = { guifg = M.colors.base00, guibg = M.colors.base02, gui = 'none', guisp = nil,
-                             ctermfg = M.colors.cterm00, ctermbg = M.colors.cterm02 }
+    hi.User1             = { guifg = M.colors.base08, guibg = M.colors.base02, gui = 'none', guisp = nil, ctermfg = M.colors.cterm08, ctermbg = M.colors.cterm02 }
+    hi.User2             = { guifg = M.colors.base0E, guibg = M.colors.base02, gui = 'none', guisp = nil, ctermfg = M.colors.cterm0E, ctermbg = M.colors.cterm02 }
+    hi.User3             = { guifg = M.colors.base05, guibg = M.colors.base02, gui = 'none', guisp = nil, ctermfg = M.colors.cterm05, ctermbg = M.colors.cterm02 }
+    hi.User4             = { guifg = M.colors.base0C, guibg = M.colors.base02, gui = 'none', guisp = nil, ctermfg = M.colors.cterm0C, ctermbg = M.colors.cterm02 }
+    hi.User5             = { guifg = M.colors.base05, guibg = M.colors.base02, gui = 'none', guisp = nil, ctermfg = M.colors.cterm05, ctermbg = M.colors.cterm02 }
+    hi.User6             = { guifg = M.colors.base05, guibg = M.colors.base01, gui = 'none', guisp = nil, ctermfg = M.colors.cterm05, ctermbg = M.colors.cterm01 }
+    hi.User7             = { guifg = M.colors.base05, guibg = M.colors.base02, gui = 'none', guisp = nil, ctermfg = M.colors.cterm05, ctermbg = M.colors.cterm02 }
+    hi.User8             = { guifg = M.colors.base00, guibg = M.colors.base02, gui = 'none', guisp = nil, ctermfg = M.colors.cterm00, ctermbg = M.colors.cterm02 }
+    hi.User9             = { guifg = M.colors.base00, guibg = M.colors.base02, gui = 'none', guisp = nil, ctermfg = M.colors.cterm00, ctermbg = M.colors.cterm02 }
 
-    hi.TreesitterContext = { guifg = nil, guibg = M.colors.base01, gui = 'italic', guisp = nil,
-                             ctermfg = nil, ctermbg = M.colors.cterm01 }
+    hi.TreesitterContext = { guifg = nil, guibg = M.colors.base01, gui = 'italic', guisp = nil, ctermfg = nil, ctermbg = M.colors.cterm01 }
 
     if M.config.telescope then
         if not M.config.telescope_borders and hex_re:match_str(M.colors.base00) and hex_re:match_str(M.colors.base01) and
@@ -702,36 +513,21 @@ function M.setup(colors, config)
     end
 
     if M.config.notify then
-        hi.NotifyERRORBorder = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil,
-                                 ctermfg = M.colors.cterm08, ctermbg = nil }
-        hi.NotifyWARNBorder  = { guifg = M.colors.base0E, guibg = nil, gui = 'none', guisp = nil,
-                                 ctermfg = M.colors.cterm0E, ctermbg = nil }
-        hi.NotifyINFOBorder  = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil,
-                                 ctermfg = M.colors.cterm05, ctermbg = nil }
-        hi.NotifyDEBUGBorder = { guifg = M.colors.base0C, guibg = nil, gui = 'none', guisp = nil,
-                                 ctermfg = M.colors.cterm0C, ctermbg = nil }
-        hi.NotifyTRACEBorder = { guifg = M.colors.base0C, guibg = nil, gui = 'none', guisp = nil,
-                                 ctermfg = M.colors.cterm0C, ctermbg = nil }
-        hi.NotifyERRORIcon   = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil,
-                                 ctermfg = M.colors.cterm08, ctermbg = nil }
-        hi.NotifyWARNIcon    = { guifg = M.colors.base0E, guibg = nil, gui = 'none', guisp = nil,
-                                 ctermfg = M.colors.cterm0E, ctermbg = nil }
-        hi.NotifyINFOIcon    = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil,
-                                 ctermfg = M.colors.cterm05, ctermbg = nil }
-        hi.NotifyDEBUGIcon   = { guifg = M.colors.base0C, guibg = nil, gui = 'none', guisp = nil,
-                                 ctermfg = M.colors.cterm0C, ctermbg = nil }
-        hi.NotifyTRACEIcon   = { guifg = M.colors.base0C, guibg = nil, gui = 'none', guisp = nil,
-                                 ctermfg = M.colors.cterm0C, ctermbg = nil }
-        hi.NotifyERRORTitle  = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil,
-                                 ctermfg = M.colors.cterm08, ctermbg = nil }
-        hi.NotifyWARNTitle   = { guifg = M.colors.base0E, guibg = nil, gui = 'none', guisp = nil,
-                                 ctermfg = M.colors.cterm0E, ctermbg = nil }
-        hi.NotifyINFOTitle   = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil,
-                                 ctermfg = M.colors.cterm05, ctermbg = nil }
-        hi.NotifyDEBUGTitle  = { guifg = M.colors.base0C, guibg = nil, gui = 'none', guisp = nil,
-                                 ctermfg = M.colors.cterm0C, ctermbg = nil }
-        hi.NotifyTRACETitle  = { guifg = M.colors.base0C, guibg = nil, gui = 'none', guisp = nil,
-                                 ctermfg = M.colors.cterm0C, ctermbg = nil }
+        hi.NotifyERRORBorder = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm08, ctermbg = nil }
+        hi.NotifyWARNBorder  = { guifg = M.colors.base0E, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm0E, ctermbg = nil }
+        hi.NotifyINFOBorder  = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm05, ctermbg = nil }
+        hi.NotifyDEBUGBorder = { guifg = M.colors.base0C, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm0C, ctermbg = nil }
+        hi.NotifyTRACEBorder = { guifg = M.colors.base0C, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm0C, ctermbg = nil }
+        hi.NotifyERRORIcon   = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm08, ctermbg = nil }
+        hi.NotifyWARNIcon    = { guifg = M.colors.base0E, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm0E, ctermbg = nil }
+        hi.NotifyINFOIcon    = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm05, ctermbg = nil }
+        hi.NotifyDEBUGIcon   = { guifg = M.colors.base0C, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm0C, ctermbg = nil }
+        hi.NotifyTRACEIcon   = { guifg = M.colors.base0C, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm0C, ctermbg = nil }
+        hi.NotifyERRORTitle  = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm08, ctermbg = nil }
+        hi.NotifyWARNTitle   = { guifg = M.colors.base0E, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm0E, ctermbg = nil }
+        hi.NotifyINFOTitle   = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm05, ctermbg = nil }
+        hi.NotifyDEBUGTitle  = { guifg = M.colors.base0C, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm0C, ctermbg = nil }
+        hi.NotifyTRACETitle  = { guifg = M.colors.base0C, guibg = nil, gui = 'none', guisp = nil, ctermfg = M.colors.cterm0C, ctermbg = nil }
         hi.NotifyERRORBody   = 'Normal'
         hi.NotifyWARNBody    = 'Normal'
         hi.NotifyINFOBody    = 'Normal'
@@ -748,73 +544,41 @@ function M.setup(colors, config)
     end
 
     if M.config.cmp then
-        hi.CmpDocumentationBorder   = { guifg = M.colors.base05, guibg = M.colors.base00, gui = nil, guisp = nil,
-                                        ctermfg = M.colors.cterm05, ctermbg = M.colors.cterm00 }
-        hi.CmpDocumentation         = { guifg = M.colors.base05, guibg = M.colors.base00, gui = nil, guisp = nil,
-                                        ctermfg = M.colors.cterm05, ctermbg = M.colors.cterm00 }
-        hi.CmpItemAbbr              = { guifg = M.colors.base05, guibg = M.colors.base01, gui = nil, guisp = nil,
-                                        ctermfg = M.colors.cterm05, ctermbg = M.colors.cterm01 }
-        hi.CmpItemAbbrDeprecated    = { guifg = M.colors.base03, guibg = nil, gui = 'strikethrough', guisp = nil,
-                                        ctermfg = M.colors.cterm03, ctermbg = nil }
-        hi.CmpItemAbbrMatch         = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil,
-                                        ctermfg = M.colors.cterm0D, ctermbg = nil }
-        hi.CmpItemAbbrMatchFuzzy    = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil,
-                                        ctermfg = M.colors.cterm0D, ctermbg = nil }
-        hi.CmpItemKindDefault       = { guifg = M.colors.base05, guibg = nil, gui = nil, guisp = nil,
-                                        ctermfg = M.colors.cterm05, ctermbg = nil }
-        hi.CmpItemMenu              = { guifg = M.colors.base04, guibg = nil, gui = nil, guisp = nil,
-                                        ctermfg = M.colors.cterm04, ctermbg = nil }
-        hi.CmpItemKindKeyword       = { guifg = M.colors.base0E, guibg = nil, gui = nil, guisp = nil,
-                                        ctermfg = M.colors.cterm0E, ctermbg = nil }
-        hi.CmpItemKindVariable      = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil,
-                                        ctermfg = M.colors.cterm08, ctermbg = nil }
-        hi.CmpItemKindConstant      = { guifg = M.colors.base09, guibg = nil, gui = nil, guisp = nil,
-                                        ctermfg = M.colors.cterm09, ctermbg = nil }
-        hi.CmpItemKindReference     = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil,
-                                        ctermfg = M.colors.cterm08, ctermbg = nil }
-        hi.CmpItemKindValue         = { guifg = M.colors.base09, guibg = nil, gui = nil, guisp = nil,
-                                        ctermfg = M.colors.cterm09, ctermbg = nil }
-        hi.CmpItemKindFunction      = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil,
-                                        ctermfg = M.colors.cterm0D, ctermbg = nil }
-        hi.CmpItemKindMethod        = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil,
-                                        ctermfg = M.colors.cterm0D, ctermbg = nil }
-        hi.CmpItemKindConstructor   = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil,
-                                        ctermfg = M.colors.cterm0D, ctermbg = nil }
-        hi.CmpItemKindClass         = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil,
-                                        ctermfg = M.colors.cterm0A, ctermbg = nil }
-        hi.CmpItemKindInterface     = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil,
-                                        ctermfg = M.colors.cterm0A, ctermbg = nil }
-        hi.CmpItemKindStruct        = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil,
-                                        ctermfg = M.colors.cterm0A, ctermbg = nil }
-        hi.CmpItemKindEvent         = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil,
-                                        ctermfg = M.colors.cterm0A, ctermbg = nil }
-        hi.CmpItemKindEnum          = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil,
-                                        ctermfg = M.colors.cterm0A, ctermbg = nil }
-        hi.CmpItemKindUnit          = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil,
-                                        ctermfg = M.colors.cterm0A, ctermbg = nil }
-        hi.CmpItemKindModule        = { guifg = M.colors.base05, guibg = nil, gui = nil, guisp = nil,
-                                        ctermfg = M.colors.cterm05, ctermbg = nil }
-        hi.CmpItemKindProperty      = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil,
-                                        ctermfg = M.colors.cterm08, ctermbg = nil }
-        hi.CmpItemKindField         = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil,
-                                        ctermfg = M.colors.cterm08, ctermbg = nil }
-        hi.CmpItemKindTypeParameter = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil,
-                                        ctermfg = M.colors.cterm0A, ctermbg = nil }
-        hi.CmpItemKindEnumMember    = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil,
-                                        ctermfg = M.colors.cterm0A, ctermbg = nil }
-        hi.CmpItemKindOperator      = { guifg = M.colors.base05, guibg = nil, gui = nil, guisp = nil,
-                                        ctermfg = M.colors.cterm05, ctermbg = nil }
-        hi.CmpItemKindSnippet       = { guifg = M.colors.base04, guibg = nil, gui = nil, guisp = nil,
-                                        ctermfg = M.colors.cterm04, ctermbg = nil }
+        hi.CmpDocumentationBorder   = { guifg = M.colors.base05, guibg = M.colors.base00, gui = nil, guisp = nil, ctermfg = M.colors.cterm05, ctermbg = M.colors.cterm00 }
+        hi.CmpDocumentation         = { guifg = M.colors.base05, guibg = M.colors.base00, gui = nil, guisp = nil, ctermfg = M.colors.cterm05, ctermbg = M.colors.cterm00 }
+        hi.CmpItemAbbr              = { guifg = M.colors.base05, guibg = M.colors.base01, gui = nil, guisp = nil, ctermfg = M.colors.cterm05, ctermbg = M.colors.cterm01 }
+        hi.CmpItemAbbrDeprecated    = { guifg = M.colors.base03, guibg = nil, gui = 'strikethrough', guisp = nil, ctermfg = M.colors.cterm03, ctermbg = nil }
+        hi.CmpItemAbbrMatch         = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm0D, ctermbg = nil }
+        hi.CmpItemAbbrMatchFuzzy    = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm0D, ctermbg = nil }
+        hi.CmpItemKindDefault       = { guifg = M.colors.base05, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm05, ctermbg = nil }
+        hi.CmpItemMenu              = { guifg = M.colors.base04, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm04, ctermbg = nil }
+        hi.CmpItemKindKeyword       = { guifg = M.colors.base0E, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm0E, ctermbg = nil }
+        hi.CmpItemKindVariable      = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm08, ctermbg = nil }
+        hi.CmpItemKindConstant      = { guifg = M.colors.base09, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm09, ctermbg = nil }
+        hi.CmpItemKindReference     = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm08, ctermbg = nil }
+        hi.CmpItemKindValue         = { guifg = M.colors.base09, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm09, ctermbg = nil }
+        hi.CmpItemKindFunction      = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm0D, ctermbg = nil }
+        hi.CmpItemKindMethod        = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm0D, ctermbg = nil }
+        hi.CmpItemKindConstructor   = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm0D, ctermbg = nil }
+        hi.CmpItemKindClass         = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm0A, ctermbg = nil }
+        hi.CmpItemKindInterface     = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm0A, ctermbg = nil }
+        hi.CmpItemKindStruct        = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm0A, ctermbg = nil }
+        hi.CmpItemKindEvent         = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm0A, ctermbg = nil }
+        hi.CmpItemKindEnum          = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm0A, ctermbg = nil }
+        hi.CmpItemKindUnit          = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm0A, ctermbg = nil }
+        hi.CmpItemKindModule        = { guifg = M.colors.base05, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm05, ctermbg = nil }
+        hi.CmpItemKindProperty      = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm08, ctermbg = nil }
+        hi.CmpItemKindField         = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm08, ctermbg = nil }
+        hi.CmpItemKindTypeParameter = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm0A, ctermbg = nil }
+        hi.CmpItemKindEnumMember    = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm0A, ctermbg = nil }
+        hi.CmpItemKindOperator      = { guifg = M.colors.base05, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm05, ctermbg = nil }
+        hi.CmpItemKindSnippet       = { guifg = M.colors.base04, guibg = nil, gui = nil, guisp = nil, ctermfg = M.colors.cterm04, ctermbg = nil }
     end
 
     if M.config.illuminate then
-        hi.IlluminatedWordText  = { guifg = nil, guibg = nil, gui = 'underline', guisp = M.colors.base04,
-                                    ctermfg = nil, ctermbg = nil }
-        hi.IlluminatedWordRead  = { guifg = nil, guibg = nil, gui = 'underline', guisp = M.colors.base04,
-                                    ctermfg = nil, ctermbg = nil }
-        hi.IlluminatedWordWrite = { guifg = nil, guibg = nil, gui = 'underline', guisp = M.colors.base04,
-                                    ctermfg = nil, ctermbg = nil }
+        hi.IlluminatedWordText  = { guifg = nil, guibg = nil, gui = 'underline', guisp = M.colors.base04, ctermfg = nil, ctermbg = nil }
+        hi.IlluminatedWordRead  = { guifg = nil, guibg = nil, gui = 'underline', guisp = M.colors.base04, ctermfg = nil, ctermbg = nil }
+        hi.IlluminatedWordWrite = { guifg = nil, guibg = nil, gui = 'underline', guisp = M.colors.base04, ctermfg = nil, ctermbg = nil }
     end
 
     if M.config.lsp_semantic then

--- a/lua/base16-colorscheme.lua
+++ b/lua/base16-colorscheme.lua
@@ -70,9 +70,12 @@ M.highlight = setmetatable({}, {
         end
 
         local guifg, guibg, gui, guisp = args.guifg or nil, args.guibg or nil, args.gui or nil, args.guisp or nil
+        local ctermfg, ctermbg = args.ctermfg or nil, args.ctermbg or nil
         local val = {}
         if guifg then val.fg = guifg end
         if guibg then val.bg = guibg end
+        if ctermfg then val.ctermfg = ctermfg end
+        if ctermbg then val.ctermbg = ctermbg end
         if guisp then val.sp = guisp end
         if gui then
             for x in string.gmatch(gui, '([^,]+)') do
@@ -127,7 +130,6 @@ function M.setup(colors, config)
     if vim.fn.exists('syntax_on') then
         vim.cmd('syntax reset')
     end
-    vim.cmd('set termguicolors')
 
     -- BASE16_THEME in a tmux session cannot be trusted because of how envs in tmux panes work.
     local base16_colorscheme = nil
@@ -140,135 +142,251 @@ function M.setup(colors, config)
     local hi                              = M.highlight
 
     -- Vim editor colors
-    hi.Normal                             = { guifg = M.colors.base05, guibg = M.colors.base00, gui = nil, guisp = nil }
+    hi.Normal                             = { guifg = M.colors.base05, guibg = M.colors.base00, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm05, ctermbg = M.colors.cterm00 }
     hi.Bold                               = { guifg = nil, guibg = nil, gui = 'bold', guisp = nil }
-    hi.Debug                              = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil }
-    hi.Directory                          = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil }
-    hi.Error                              = { guifg = M.colors.base08, guibg = M.colors.base00, gui = nil, guisp = nil }
-    hi.ErrorMsg                           = { guifg = M.colors.base08, guibg = M.colors.base00, gui = nil, guisp = nil }
-    hi.Exception                          = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil }
-    hi.FoldColumn                         = { guifg = M.colors.base0C, guibg = M.colors.base00, gui = nil, guisp = nil }
-    hi.Folded                             = { guifg = M.colors.base03, guibg = M.colors.base01, gui = nil, guisp = nil }
-    hi.IncSearch                          = { guifg = M.colors.base01, guibg = M.colors.base09, gui = 'none', guisp = nil }
-    hi.Italic                             = { guifg = nil, guibg = nil, gui = 'none', guisp = nil }
-    hi.Macro                              = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil }
-    hi.MatchParen                         = { guifg = nil, guibg = M.colors.base03, gui = nil, guisp = nil }
-    hi.ModeMsg                            = { guifg = M.colors.base0B, guibg = nil, gui = nil, guisp = nil }
-    hi.MoreMsg                            = { guifg = M.colors.base0B, guibg = nil, gui = nil, guisp = nil }
-    hi.Question                           = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil }
-    hi.Search                             = { guifg = M.colors.base01, guibg = M.colors.base0A, gui = nil, guisp = nil }
-    hi.Substitute                         = { guifg = M.colors.base01, guibg = M.colors.base0A, gui = 'none', guisp = nil }
-    hi.SpecialKey                         = { guifg = M.colors.base03, guibg = nil, gui = nil, guisp = nil }
-    hi.TooLong                            = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil }
-    hi.Underlined                         = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil }
-    hi.Visual                             = { guifg = nil, guibg = M.colors.base02, gui = nil, guisp = nil }
-    hi.VisualNOS                          = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil }
-    hi.WarningMsg                         = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil }
-    hi.WildMenu                           = { guifg = M.colors.base08, guibg = M.colors.base0A, gui = nil, guisp = nil }
-    hi.Title                              = { guifg = M.colors.base0D, guibg = nil, gui = 'none', guisp = nil }
-    hi.Conceal                            = { guifg = M.colors.base0D, guibg = M.colors.base00, gui = nil, guisp = nil }
-    hi.Cursor                             = { guifg = M.colors.base00, guibg = M.colors.base05, gui = nil, guisp = nil }
-    hi.NonText                            = { guifg = M.colors.base03, guibg = nil, gui = nil, guisp = nil }
-    hi.LineNr                             = { guifg = M.colors.base04, guibg = M.colors.base00, gui = nil, guisp = nil }
-    hi.SignColumn                         = { guifg = M.colors.base04, guibg = M.colors.base00, gui = nil, guisp = nil }
-    hi.StatusLine                         = { guifg = M.colors.base05, guibg = M.colors.base02, gui = 'none', guisp = nil }
-    hi.StatusLineNC                       = { guifg = M.colors.base04, guibg = M.colors.base01, gui = 'none', guisp = nil }
-    hi.WinBar                             = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil }
-    hi.WinBarNC                           = { guifg = M.colors.base04, guibg = nil, gui = 'none', guisp = nil }
-    hi.VertSplit                          = { guifg = M.colors.base05, guibg = M.colors.base00, gui = 'none', guisp = nil }
-    hi.ColorColumn                        = { guifg = nil, guibg = M.colors.base01, gui = 'none', guisp = nil }
-    hi.CursorColumn                       = { guifg = nil, guibg = M.colors.base01, gui = 'none', guisp = nil }
-    hi.CursorLine                         = { guifg = nil, guibg = M.colors.base01, gui = 'none', guisp = nil }
-    hi.CursorLineNr                       = { guifg = M.colors.base04, guibg = M.colors.base01, gui = nil, guisp = nil }
-    hi.QuickFixLine                       = { guifg = nil, guibg = M.colors.base01, gui = 'none', guisp = nil }
-    hi.PMenu                              = { guifg = M.colors.base05, guibg = M.colors.base01, gui = 'none', guisp = nil }
-    hi.PMenuSel                           = { guifg = M.colors.base01, guibg = M.colors.base05, gui = nil, guisp = nil }
-    hi.TabLine                            = { guifg = M.colors.base03, guibg = M.colors.base01, gui = 'none', guisp = nil }
-    hi.TabLineFill                        = { guifg = M.colors.base03, guibg = M.colors.base01, gui = 'none', guisp = nil }
-    hi.TabLineSel                         = { guifg = M.colors.base0B, guibg = M.colors.base01, gui = 'none', guisp = nil }
+    hi.Debug                              = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm08, ctermbg = nil }
+    hi.Directory                          = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm0D, ctermbg = nil }
+    hi.Error                              = { guifg = M.colors.base08, guibg = M.colors.base00, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm08, ctermbg = M.colors.cterm00 }
+    hi.ErrorMsg                           = { guifg = M.colors.base08, guibg = M.colors.base00, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm08, ctermbg = M.colors.cterm00 }
+    hi.Exception                          = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm08, ctermbg = nil }
+    hi.FoldColumn                         = { guifg = M.colors.base0C, guibg = M.colors.base00, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm0C, ctermbg = M.colors.cterm00 }
+    hi.Folded                             = { guifg = M.colors.base03, guibg = M.colors.base01, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm03, ctermbg = M.colors.cterm01 }
+    hi.IncSearch                          = { guifg = M.colors.base01, guibg = M.colors.base09, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm01, ctermbg = M.colors.cterm09 }
+    hi.Italic                             = { guifg = nil, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = nil, ctermbg = nil }
+    hi.Macro                              = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm08, ctermbg = nil }
+    hi.MatchParen                         = { guifg = nil, guibg = M.colors.base03, gui = nil, guisp = nil,
+                                              ctermfg = nil, ctermbg = M.colors.cterm03 }
+    hi.ModeMsg                            = { guifg = M.colors.base0B, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm0B, ctermbg = nil }
+    hi.MoreMsg                            = { guifg = M.colors.base0B, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm0B, ctermbg = nil }
+    hi.Question                           = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm0D, ctermbg = nil }
+    hi.Search                             = { guifg = M.colors.base01, guibg = M.colors.base0A, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm01, ctermbg = M.colors.cterm0A }
+    hi.Substitute                         = { guifg = M.colors.base01, guibg = M.colors.base0A, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm01, ctermbg = M.colors.cterm0A }
+    hi.SpecialKey                         = { guifg = M.colors.base03, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm03, ctermbg = nil }
+    hi.TooLong                            = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm08, ctermbg = nil }
+    hi.Underlined                         = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm08, ctermbg = nil }
+    hi.Visual                             = { guifg = nil, guibg = M.colors.base02, gui = nil, guisp = nil,
+                                              ctermfg = nil, ctermbg = M.colors.cterm02 }
+    hi.VisualNOS                          = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm08, ctermbg = nil }
+    hi.WarningMsg                         = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm08, ctermbg = nil }
+    hi.WildMenu                           = { guifg = M.colors.base08, guibg = M.colors.base0A, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm08, ctermbg = M.colors.cterm0A }
+    hi.Title                              = { guifg = M.colors.base0D, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm0D, ctermbg = nil }
+    hi.Conceal                            = { guifg = M.colors.base0D, guibg = M.colors.base00, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm0D, ctermbg = M.colors.cterm00 }
+    hi.Cursor                             = { guifg = M.colors.base00, guibg = M.colors.base05, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm00, ctermbg = M.colors.cterm05 }
+    hi.NonText                            = { guifg = M.colors.base03, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm03, ctermbg = nil }
+    hi.LineNr                             = { guifg = M.colors.base04, guibg = M.colors.base00, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm04, ctermbg = M.colors.cterm00 }
+    hi.SignColumn                         = { guifg = M.colors.base04, guibg = M.colors.base00, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm04, ctermbg = M.colors.cterm00 }
+    hi.StatusLine                         = { guifg = M.colors.base05, guibg = M.colors.base02, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm05, ctermbg = M.colors.cterm02 }
+    hi.StatusLineNC                       = { guifg = M.colors.base04, guibg = M.colors.base01, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm04, ctermbg = M.colors.cterm01 }
+    hi.WinBar                             = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm05, ctermbg = nil }
+    hi.WinBarNC                           = { guifg = M.colors.base04, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm04, ctermbg = nil }
+    hi.VertSplit                          = { guifg = M.colors.base05, guibg = M.colors.base00, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm05, ctermbg = M.colors.cterm00 }
+    hi.ColorColumn                        = { guifg = nil, guibg = M.colors.base01, gui = 'none', guisp = nil,
+                                              ctermfg = nil, ctermbg = M.colors.cterm01 }
+    hi.CursorColumn                       = { guifg = nil, guibg = M.colors.base01, gui = 'none', guisp = nil,
+                                              ctermfg = nil, ctermbg = M.colors.cterm01 }
+    hi.CursorLine                         = { guifg = nil, guibg = M.colors.base01, gui = 'none', guisp = nil,
+                                              ctermfg = nil, ctermbg = M.colors.cterm01 }
+    hi.CursorLineNr                       = { guifg = M.colors.base04, guibg = M.colors.base01, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm04, ctermbg = M.colors.cterm01 }
+    hi.QuickFixLine                       = { guifg = nil, guibg = M.colors.base01, gui = 'none', guisp = nil,
+                                              ctermfg = nil, ctermbg = M.colors.cterm01 }
+    hi.PMenu                              = { guifg = M.colors.base05, guibg = M.colors.base01, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm05, ctermbg = M.colors.cterm01 }
+    hi.PMenuSel                           = { guifg = M.colors.base01, guibg = M.colors.base05, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm01, ctermbg = M.colors.cterm05 }
+    hi.TabLine                            = { guifg = M.colors.base03, guibg = M.colors.base01, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm03, ctermbg = M.colors.cterm01 }
+    hi.TabLineFill                        = { guifg = M.colors.base03, guibg = M.colors.base01, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm03, ctermbg = M.colors.cterm01 }
+    hi.TabLineSel                         = { guifg = M.colors.base0B, guibg = M.colors.base01, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm0B, ctermbg = M.colors.cterm01 }
 
     -- Standard syntax highlighting
-    hi.Boolean                            = { guifg = M.colors.base09, guibg = nil, gui = nil, guisp = nil }
-    hi.Character                          = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil }
-    hi.Comment                            = { guifg = M.colors.base03, guibg = nil, gui = nil, guisp = nil }
-    hi.Conditional                        = { guifg = M.colors.base0E, guibg = nil, gui = nil, guisp = nil }
-    hi.Constant                           = { guifg = M.colors.base09, guibg = nil, gui = nil, guisp = nil }
-    hi.Define                             = { guifg = M.colors.base0E, guibg = nil, gui = 'none', guisp = nil }
-    hi.Delimiter                          = { guifg = M.colors.base0F, guibg = nil, gui = nil, guisp = nil }
-    hi.Float                              = { guifg = M.colors.base09, guibg = nil, gui = nil, guisp = nil }
-    hi.Function                           = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil }
-    hi.Identifier                         = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil }
-    hi.Include                            = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil }
-    hi.Keyword                            = { guifg = M.colors.base0E, guibg = nil, gui = nil, guisp = nil }
-    hi.Label                              = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil }
-    hi.Number                             = { guifg = M.colors.base09, guibg = nil, gui = nil, guisp = nil }
-    hi.Operator                           = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil }
-    hi.PreProc                            = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil }
-    hi.Repeat                             = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil }
-    hi.Special                            = { guifg = M.colors.base0C, guibg = nil, gui = nil, guisp = nil }
-    hi.SpecialChar                        = { guifg = M.colors.base0F, guibg = nil, gui = nil, guisp = nil }
-    hi.Statement                          = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil }
-    hi.StorageClass                       = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil }
-    hi.String                             = { guifg = M.colors.base0B, guibg = nil, gui = nil, guisp = nil }
-    hi.Structure                          = { guifg = M.colors.base0E, guibg = nil, gui = nil, guisp = nil }
-    hi.Tag                                = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil }
-    hi.Todo                               = { guifg = M.colors.base0A, guibg = M.colors.base01, gui = nil, guisp = nil }
-    hi.Type                               = { guifg = M.colors.base0A, guibg = nil, gui = 'none', guisp = nil }
-    hi.Typedef                            = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil }
+    hi.Boolean                            = { guifg = M.colors.base09, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm09, ctermbg = nil }
+    hi.Character                          = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm08, ctermbg = nil }
+    hi.Comment                            = { guifg = M.colors.base03, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm03, ctermbg = nil }
+    hi.Conditional                        = { guifg = M.colors.base0E, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm0E, ctermbg = nil }
+    hi.Constant                           = { guifg = M.colors.base09, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm09, ctermbg = nil }
+    hi.Define                             = { guifg = M.colors.base0E, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm0E, ctermbg = nil }
+    hi.Delimiter                          = { guifg = M.colors.base0F, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm0F, ctermbg = nil }
+    hi.Float                              = { guifg = M.colors.base09, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm09, ctermbg = nil }
+    hi.Function                           = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm0D, ctermbg = nil }
+    hi.Identifier                         = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm08, ctermbg = nil }
+    hi.Include                            = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm0D, ctermbg = nil }
+    hi.Keyword                            = { guifg = M.colors.base0E, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm0E, ctermbg = nil }
+    hi.Label                              = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm0A, ctermbg = nil }
+    hi.Number                             = { guifg = M.colors.base09, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm09, ctermbg = nil }
+    hi.Operator                           = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm05, ctermbg = nil }
+    hi.PreProc                            = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm0A, ctermbg = nil }
+    hi.Repeat                             = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm0A, ctermbg = nil }
+    hi.Special                            = { guifg = M.colors.base0C, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm0C, ctermbg = nil }
+    hi.SpecialChar                        = { guifg = M.colors.base0F, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm0F, ctermbg = nil }
+    hi.Statement                          = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm08, ctermbg = nil }
+    hi.StorageClass                       = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm0A, ctermbg = nil }
+    hi.String                             = { guifg = M.colors.base0B, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm0B, ctermbg = nil }
+    hi.Structure                          = { guifg = M.colors.base0E, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm0E, ctermbg = nil }
+    hi.Tag                                = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm0A, ctermbg = nil }
+    hi.Todo                               = { guifg = M.colors.base0A, guibg = M.colors.base01, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm0A, ctermbg = M.colors.cterm01 }
+    hi.Type                               = { guifg = M.colors.base0A, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm0A, ctermbg = nil }
+    hi.Typedef                            = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm0A, ctermbg = nil }
 
     -- Diff highlighting
-    hi.DiffAdd                            = { guifg = M.colors.base0B, guibg = M.colors.base00, gui = nil, guisp = nil }
-    hi.DiffChange                         = { guifg = M.colors.base03, guibg = M.colors.base00, gui = nil, guisp = nil }
-    hi.DiffDelete                         = { guifg = M.colors.base08, guibg = M.colors.base00, gui = nil, guisp = nil }
-    hi.DiffText                           = { guifg = M.colors.base0D, guibg = M.colors.base00, gui = nil, guisp = nil }
-    hi.DiffAdded                          = { guifg = M.colors.base0B, guibg = M.colors.base00, gui = nil, guisp = nil }
-    hi.DiffFile                           = { guifg = M.colors.base08, guibg = M.colors.base00, gui = nil, guisp = nil }
-    hi.DiffNewFile                        = { guifg = M.colors.base0B, guibg = M.colors.base00, gui = nil, guisp = nil }
-    hi.DiffLine                           = { guifg = M.colors.base0D, guibg = M.colors.base00, gui = nil, guisp = nil }
-    hi.DiffRemoved                        = { guifg = M.colors.base08, guibg = M.colors.base00, gui = nil, guisp = nil }
+    hi.DiffAdd                            = { guifg = M.colors.base0B, guibg = M.colors.base00, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm0B, ctermbg = M.colors.cterm00 }
+    hi.DiffChange                         = { guifg = M.colors.base03, guibg = M.colors.base00, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm03, ctermbg = M.colors.cterm00 }
+    hi.DiffDelete                         = { guifg = M.colors.base08, guibg = M.colors.base00, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm08, ctermbg = M.colors.cterm00 }
+    hi.DiffText                           = { guifg = M.colors.base0D, guibg = M.colors.base00, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm0D, ctermbg = M.colors.cterm00 }
+    hi.DiffAdded                          = { guifg = M.colors.base0B, guibg = M.colors.base00, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm0B, ctermbg = M.colors.cterm00 }
+    hi.DiffFile                           = { guifg = M.colors.base08, guibg = M.colors.base00, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm08, ctermbg = M.colors.cterm00 }
+    hi.DiffNewFile                        = { guifg = M.colors.base0B, guibg = M.colors.base00, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm0B, ctermbg = M.colors.cterm00 }
+    hi.DiffLine                           = { guifg = M.colors.base0D, guibg = M.colors.base00, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm0D, ctermbg = M.colors.cterm00 }
+    hi.DiffRemoved                        = { guifg = M.colors.base08, guibg = M.colors.base00, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm08, ctermbg = M.colors.cterm00 }
 
     -- Git highlighting
-    hi.gitcommitOverflow                  = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil }
-    hi.gitcommitSummary                   = { guifg = M.colors.base0B, guibg = nil, gui = nil, guisp = nil }
-    hi.gitcommitComment                   = { guifg = M.colors.base03, guibg = nil, gui = nil, guisp = nil }
-    hi.gitcommitUntracked                 = { guifg = M.colors.base03, guibg = nil, gui = nil, guisp = nil }
-    hi.gitcommitDiscarded                 = { guifg = M.colors.base03, guibg = nil, gui = nil, guisp = nil }
-    hi.gitcommitSelected                  = { guifg = M.colors.base03, guibg = nil, gui = nil, guisp = nil }
-    hi.gitcommitHeader                    = { guifg = M.colors.base0E, guibg = nil, gui = nil, guisp = nil }
-    hi.gitcommitSelectedType              = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil }
-    hi.gitcommitUnmergedType              = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil }
-    hi.gitcommitDiscardedType             = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil }
-    hi.gitcommitBranch                    = { guifg = M.colors.base09, guibg = nil, gui = 'bold', guisp = nil }
-    hi.gitcommitUntrackedFile             = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil }
-    hi.gitcommitUnmergedFile              = { guifg = M.colors.base08, guibg = nil, gui = 'bold', guisp = nil }
-    hi.gitcommitDiscardedFile             = { guifg = M.colors.base08, guibg = nil, gui = 'bold', guisp = nil }
-    hi.gitcommitSelectedFile              = { guifg = M.colors.base0B, guibg = nil, gui = 'bold', guisp = nil }
+    hi.gitcommitOverflow                  = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm08, ctermbg = nil }
+    hi.gitcommitSummary                   = { guifg = M.colors.base0B, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm0B, ctermbg = nil }
+    hi.gitcommitComment                   = { guifg = M.colors.base03, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm03, ctermbg = nil }
+    hi.gitcommitUntracked                 = { guifg = M.colors.base03, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm03, ctermbg = nil }
+    hi.gitcommitDiscarded                 = { guifg = M.colors.base03, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm03, ctermbg = nil }
+    hi.gitcommitSelected                  = { guifg = M.colors.base03, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm03, ctermbg = nil }
+    hi.gitcommitHeader                    = { guifg = M.colors.base0E, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm0E, ctermbg = nil }
+    hi.gitcommitSelectedType              = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm0D, ctermbg = nil }
+    hi.gitcommitUnmergedType              = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm0D, ctermbg = nil }
+    hi.gitcommitDiscardedType             = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm0D, ctermbg = nil }
+    hi.gitcommitBranch                    = { guifg = M.colors.base09, guibg = nil, gui = 'bold', guisp = nil,
+                                              ctermfg = M.colors.cterm09, ctermbg = nil }
+    hi.gitcommitUntrackedFile             = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm0A, ctermbg = nil }
+    hi.gitcommitUnmergedFile              = { guifg = M.colors.base08, guibg = nil, gui = 'bold', guisp = nil,
+                                              ctermfg = M.colors.cterm08, ctermbg = nil }
+    hi.gitcommitDiscardedFile             = { guifg = M.colors.base08, guibg = nil, gui = 'bold', guisp = nil,
+                                              ctermfg = M.colors.cterm08, ctermbg = nil }
+    hi.gitcommitSelectedFile              = { guifg = M.colors.base0B, guibg = nil, gui = 'bold', guisp = nil,
+                                              ctermfg = M.colors.cterm0B, ctermbg = nil }
 
     -- GitGutter highlighting
-    hi.GitGutterAdd                       = { guifg = M.colors.base0B, guibg = M.colors.base00, gui = nil, guisp = nil }
-    hi.GitGutterChange                    = { guifg = M.colors.base0D, guibg = M.colors.base00, gui = nil, guisp = nil }
-    hi.GitGutterDelete                    = { guifg = M.colors.base08, guibg = M.colors.base00, gui = nil, guisp = nil }
-    hi.GitGutterChangeDelete              = { guifg = M.colors.base0E, guibg = M.colors.base00, gui = nil, guisp = nil }
+    hi.GitGutterAdd                       = { guifg = M.colors.base0B, guibg = M.colors.base00, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm0B, ctermbg = M.colors.cterm00 }
+    hi.GitGutterChange                    = { guifg = M.colors.base0D, guibg = M.colors.base00, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm0D, ctermbg = M.colors.cterm00 }
+    hi.GitGutterDelete                    = { guifg = M.colors.base08, guibg = M.colors.base00, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm08, ctermbg = M.colors.cterm00 }
+    hi.GitGutterChangeDelete              = { guifg = M.colors.base0E, guibg = M.colors.base00, gui = nil, guisp = nil,
+                                              ctermfg = M.colors.cterm0E, ctermbg = M.colors.cterm00 }
 
     -- Spelling highlighting
-    hi.SpellBad                           = { guifg = nil, guibg = nil, gui = 'undercurl', guisp = M.colors.base08 }
-    hi.SpellLocal                         = { guifg = nil, guibg = nil, gui = 'undercurl', guisp = M.colors.base0C }
-    hi.SpellCap                           = { guifg = nil, guibg = nil, gui = 'undercurl', guisp = M.colors.base0D }
-    hi.SpellRare                          = { guifg = nil, guibg = nil, gui = 'undercurl', guisp = M.colors.base0E }
+    hi.SpellBad                           = { guifg = nil, guibg = nil, gui = 'undercurl', guisp = M.colors.base08,
+                                              ctermfg = nil, ctermbg = nil }
+    hi.SpellLocal                         = { guifg = nil, guibg = nil, gui = 'undercurl', guisp = M.colors.base0C,
+                                              ctermfg = nil, ctermbg = nil }
+    hi.SpellCap                           = { guifg = nil, guibg = nil, gui = 'undercurl', guisp = M.colors.base0D,
+                                              ctermfg = nil, ctermbg = nil }
+    hi.SpellRare                          = { guifg = nil, guibg = nil, gui = 'undercurl', guisp = M.colors.base0E,
+                                              ctermfg = nil, ctermbg = nil }
 
-    hi.DiagnosticError                    = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil }
-    hi.DiagnosticWarn                     = { guifg = M.colors.base0E, guibg = nil, gui = 'none', guisp = nil }
-    hi.DiagnosticInfo                     = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil }
-    hi.DiagnosticHint                     = { guifg = M.colors.base0C, guibg = nil, gui = 'none', guisp = nil }
-    hi.DiagnosticUnderlineError           = { guifg = nil, guibg = nil, gui = 'undercurl', guisp = M.colors.base08 }
-    hi.DiagnosticUnderlineWarning         = { guifg = nil, guibg = nil, gui = 'undercurl', guisp = M.colors.base0E }
-    hi.DiagnosticUnderlineWarn            = { guifg = nil, guibg = nil, gui = 'undercurl', guisp = M.colors.base0E }
-    hi.DiagnosticUnderlineInformation     = { guifg = nil, guibg = nil, gui = 'undercurl', guisp = M.colors.base0F }
-    hi.DiagnosticUnderlineHint            = { guifg = nil, guibg = nil, gui = 'undercurl', guisp = M.colors.base0C }
+    hi.DiagnosticError                    = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm08, ctermbg = nil }
+    hi.DiagnosticWarn                     = { guifg = M.colors.base0E, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm0E, ctermbg = nil }
+    hi.DiagnosticInfo                     = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm05, ctermbg = nil }
+    hi.DiagnosticHint                     = { guifg = M.colors.base0C, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm0C, ctermbg = nil }
+    hi.DiagnosticUnderlineError           = { guifg = nil, guibg = nil, gui = 'undercurl', guisp = M.colors.base08,
+                                              ctermfg = nil, ctermbg = nil }
+    hi.DiagnosticUnderlineWarning         = { guifg = nil, guibg = nil, gui = 'undercurl', guisp = M.colors.base0E,
+                                              ctermfg = nil, ctermbg = nil }
+    hi.DiagnosticUnderlineWarn            = { guifg = nil, guibg = nil, gui = 'undercurl', guisp = M.colors.base0E,
+                                              ctermfg = nil, ctermbg = nil }
+    hi.DiagnosticUnderlineInformation     = { guifg = nil, guibg = nil, gui = 'undercurl', guisp = M.colors.base0F,
+                                              ctermfg = nil, ctermbg = nil }
+    hi.DiagnosticUnderlineHint            = { guifg = nil, guibg = nil, gui = 'undercurl', guisp = M.colors.base0C,
+                                              ctermfg = nil, ctermbg = nil }
 
-    hi.LspReferenceText                   = { guifg = nil, guibg = nil, gui = 'underline', guisp = M.colors.base04 }
-    hi.LspReferenceRead                   = { guifg = nil, guibg = nil, gui = 'underline', guisp = M.colors.base04 }
-    hi.LspReferenceWrite                  = { guifg = nil, guibg = nil, gui = 'underline', guisp = M.colors.base04 }
+    hi.LspReferenceText                   = { guifg = nil, guibg = nil, gui = 'underline', guisp = M.colors.base04,
+                                              ctermfg = nil, ctermbg = nil }
+    hi.LspReferenceRead                   = { guifg = nil, guibg = nil, gui = 'underline', guisp = M.colors.base04,
+                                              ctermfg = nil, ctermbg = nil }
+    hi.LspReferenceWrite                  = { guifg = nil, guibg = nil, gui = 'underline', guisp = M.colors.base04,
+                                              ctermfg = nil, ctermbg = nil }
     hi.LspDiagnosticsDefaultError         = 'DiagnosticError'
     hi.LspDiagnosticsDefaultWarning       = 'DiagnosticWarn'
     hi.LspDiagnosticsDefaultInformation   = 'DiagnosticInfo'
@@ -278,64 +396,120 @@ function M.setup(colors, config)
     hi.LspDiagnosticsUnderlineInformation = 'DiagnosticUnderlineInformation'
     hi.LspDiagnosticsUnderlineHint        = 'DiagnosticUnderlineHint'
 
-    hi.TSAnnotation                       = { guifg = M.colors.base0F, guibg = nil, gui = 'none', guisp = nil }
-    hi.TSAttribute                        = { guifg = M.colors.base0A, guibg = nil, gui = 'none', guisp = nil }
-    hi.TSBoolean                          = { guifg = M.colors.base09, guibg = nil, gui = 'none', guisp = nil }
-    hi.TSCharacter                        = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil }
-    hi.TSComment                          = { guifg = M.colors.base03, guibg = nil, gui = 'italic', guisp = nil }
-    hi.TSConstructor                      = { guifg = M.colors.base0D, guibg = nil, gui = 'none', guisp = nil }
-    hi.TSConditional                      = { guifg = M.colors.base0E, guibg = nil, gui = 'none', guisp = nil }
-    hi.TSConstant                         = { guifg = M.colors.base09, guibg = nil, gui = 'none', guisp = nil }
-    hi.TSConstBuiltin                     = { guifg = M.colors.base09, guibg = nil, gui = 'italic', guisp = nil }
-    hi.TSConstMacro                       = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil }
-    hi.TSError                            = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil }
-    hi.TSException                        = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil }
-    hi.TSField                            = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil }
-    hi.TSFloat                            = { guifg = M.colors.base09, guibg = nil, gui = 'none', guisp = nil }
-    hi.TSFunction                         = { guifg = M.colors.base0D, guibg = nil, gui = 'none', guisp = nil }
-    hi.TSFuncBuiltin                      = { guifg = M.colors.base0D, guibg = nil, gui = 'italic', guisp = nil }
-    hi.TSFuncMacro                        = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil }
-    hi.TSInclude                          = { guifg = M.colors.base0D, guibg = nil, gui = 'none', guisp = nil }
-    hi.TSKeyword                          = { guifg = M.colors.base0E, guibg = nil, gui = 'none', guisp = nil }
-    hi.TSKeywordFunction                  = { guifg = M.colors.base0E, guibg = nil, gui = 'none', guisp = nil }
-    hi.TSKeywordOperator                  = { guifg = M.colors.base0E, guibg = nil, gui = 'none', guisp = nil }
-    hi.TSLabel                            = { guifg = M.colors.base0A, guibg = nil, gui = 'none', guisp = nil }
-    hi.TSMethod                           = { guifg = M.colors.base0D, guibg = nil, gui = 'none', guisp = nil }
-    hi.TSNamespace                        = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil }
-    hi.TSNone                             = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil }
-    hi.TSNumber                           = { guifg = M.colors.base09, guibg = nil, gui = 'none', guisp = nil }
-    hi.TSOperator                         = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil }
-    hi.TSParameter                        = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil }
-    hi.TSParameterReference               = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil }
-    hi.TSProperty                         = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil }
-    hi.TSPunctDelimiter                   = { guifg = M.colors.base0F, guibg = nil, gui = 'none', guisp = nil }
-    hi.TSPunctBracket                     = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil }
-    hi.TSPunctSpecial                     = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil }
-    hi.TSRepeat                           = { guifg = M.colors.base0E, guibg = nil, gui = 'none', guisp = nil }
-    hi.TSString                           = { guifg = M.colors.base0B, guibg = nil, gui = 'none', guisp = nil }
-    hi.TSStringRegex                      = { guifg = M.colors.base0C, guibg = nil, gui = 'none', guisp = nil }
-    hi.TSStringEscape                     = { guifg = M.colors.base0C, guibg = nil, gui = 'none', guisp = nil }
-    hi.TSSymbol                           = { guifg = M.colors.base0B, guibg = nil, gui = 'none', guisp = nil }
-    hi.TSTag                              = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil }
-    hi.TSTagDelimiter                     = { guifg = M.colors.base0F, guibg = nil, gui = 'none', guisp = nil }
-    hi.TSText                             = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil }
-    hi.TSStrong                           = { guifg = nil, guibg = nil, gui = 'bold', guisp = nil }
-    hi.TSEmphasis                         = { guifg = M.colors.base09, guibg = nil, gui = 'italic', guisp = nil }
-    hi.TSUnderline                        = { guifg = M.colors.base00, guibg = nil, gui = 'underline', guisp = nil }
-    hi.TSStrike                           = { guifg = M.colors.base00, guibg = nil, gui = 'strikethrough', guisp = nil }
-    hi.TSTitle                            = { guifg = M.colors.base0D, guibg = nil, gui = 'none', guisp = nil }
-    hi.TSLiteral                          = { guifg = M.colors.base09, guibg = nil, gui = 'none', guisp = nil }
-    hi.TSURI                              = { guifg = M.colors.base09, guibg = nil, gui = 'underline', guisp = nil }
-    hi.TSType                             = { guifg = M.colors.base0A, guibg = nil, gui = 'none', guisp = nil }
-    hi.TSTypeBuiltin                      = { guifg = M.colors.base0A, guibg = nil, gui = 'italic', guisp = nil }
-    hi.TSVariable                         = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil }
-    hi.TSVariableBuiltin                  = { guifg = M.colors.base08, guibg = nil, gui = 'italic', guisp = nil }
+    hi.TSAnnotation                       = { guifg = M.colors.base0F, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm0F, ctermbg = nil }
+    hi.TSAttribute                        = { guifg = M.colors.base0A, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm0A, ctermbg = nil }
+    hi.TSBoolean                          = { guifg = M.colors.base09, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm09, ctermbg = nil }
+    hi.TSCharacter                        = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm08, ctermbg = nil }
+    hi.TSComment                          = { guifg = M.colors.base03, guibg = nil, gui = 'italic', guisp = nil,
+                                              ctermfg = M.colors.cterm03, ctermbg = nil }
+    hi.TSConstructor                      = { guifg = M.colors.base0D, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm0D, ctermbg = nil }
+    hi.TSConditional                      = { guifg = M.colors.base0E, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm0E, ctermbg = nil }
+    hi.TSConstant                         = { guifg = M.colors.base09, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm09, ctermbg = nil }
+    hi.TSConstBuiltin                     = { guifg = M.colors.base09, guibg = nil, gui = 'italic', guisp = nil,
+                                              ctermfg = M.colors.cterm09, ctermbg = nil }
+    hi.TSConstMacro                       = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm08, ctermbg = nil }
+    hi.TSError                            = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm08, ctermbg = nil }
+    hi.TSException                        = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm08, ctermbg = nil }
+    hi.TSField                            = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm05, ctermbg = nil }
+    hi.TSFloat                            = { guifg = M.colors.base09, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm09, ctermbg = nil }
+    hi.TSFunction                         = { guifg = M.colors.base0D, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm0D, ctermbg = nil }
+    hi.TSFuncBuiltin                      = { guifg = M.colors.base0D, guibg = nil, gui = 'italic', guisp = nil,
+                                              ctermfg = M.colors.cterm0D, ctermbg = nil }
+    hi.TSFuncMacro                        = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm08, ctermbg = nil }
+    hi.TSInclude                          = { guifg = M.colors.base0D, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm0D, ctermbg = nil }
+    hi.TSKeyword                          = { guifg = M.colors.base0E, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm0E, ctermbg = nil }
+    hi.TSKeywordFunction                  = { guifg = M.colors.base0E, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm0E, ctermbg = nil }
+    hi.TSKeywordOperator                  = { guifg = M.colors.base0E, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm0E, ctermbg = nil }
+    hi.TSLabel                            = { guifg = M.colors.base0A, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm0A, ctermbg = nil }
+    hi.TSMethod                           = { guifg = M.colors.base0D, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm0D, ctermbg = nil }
+    hi.TSNamespace                        = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm08, ctermbg = nil }
+    hi.TSNone                             = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm05, ctermbg = nil }
+    hi.TSNumber                           = { guifg = M.colors.base09, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm09, ctermbg = nil }
+    hi.TSOperator                         = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm05, ctermbg = nil }
+    hi.TSParameter                        = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm05, ctermbg = nil }
+    hi.TSParameterReference               = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm05, ctermbg = nil }
+    hi.TSProperty                         = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm05, ctermbg = nil }
+    hi.TSPunctDelimiter                   = { guifg = M.colors.base0F, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm0F, ctermbg = nil }
+    hi.TSPunctBracket                     = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm05, ctermbg = nil }
+    hi.TSPunctSpecial                     = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm05, ctermbg = nil }
+    hi.TSRepeat                           = { guifg = M.colors.base0E, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm0E, ctermbg = nil }
+    hi.TSString                           = { guifg = M.colors.base0B, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm0B, ctermbg = nil }
+    hi.TSStringRegex                      = { guifg = M.colors.base0C, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm0C, ctermbg = nil }
+    hi.TSStringEscape                     = { guifg = M.colors.base0C, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm0C, ctermbg = nil }
+    hi.TSSymbol                           = { guifg = M.colors.base0B, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm0B, ctermbg = nil }
+    hi.TSTag                              = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm08, ctermbg = nil }
+    hi.TSTagDelimiter                     = { guifg = M.colors.base0F, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm0F, ctermbg = nil }
+    hi.TSText                             = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm05, ctermbg = nil }
+    hi.TSStrong                           = { guifg = nil, guibg = nil, gui = 'bold', guisp = nil,
+                                              ctermfg = nil, ctermbg = nil }
+    hi.TSEmphasis                         = { guifg = M.colors.base09, guibg = nil, gui = 'italic', guisp = nil,
+                                              ctermfg = M.colors.cterm09, ctermbg = nil }
+    hi.TSUnderline                        = { guifg = M.colors.base00, guibg = nil, gui = 'underline', guisp = nil,
+                                              ctermfg = M.colors.cterm00, ctermbg = nil }
+    hi.TSStrike                           = { guifg = M.colors.base00, guibg = nil, gui = 'strikethrough', guisp = nil,
+                                              ctermfg = M.colors.cterm00, ctermbg = nil }
+    hi.TSTitle                            = { guifg = M.colors.base0D, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm0D, ctermbg = nil }
+    hi.TSLiteral                          = { guifg = M.colors.base09, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm09, ctermbg = nil }
+    hi.TSURI                              = { guifg = M.colors.base09, guibg = nil, gui = 'underline', guisp = nil,
+                                              ctermfg = M.colors.cterm09, ctermbg = nil }
+    hi.TSType                             = { guifg = M.colors.base0A, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm0A, ctermbg = nil }
+    hi.TSTypeBuiltin                      = { guifg = M.colors.base0A, guibg = nil, gui = 'italic', guisp = nil,
+                                              ctermfg = M.colors.cterm0A, ctermbg = nil }
+    hi.TSVariable                         = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil,
+                                              ctermfg = M.colors.cterm08, ctermbg = nil }
+    hi.TSVariableBuiltin                  = { guifg = M.colors.base08, guibg = nil, gui = 'italic', guisp = nil,
+                                              ctermfg = M.colors.cterm08, ctermbg = nil }
 
-    hi.TSDefinition                       = { guifg = nil, guibg = nil, gui = 'underline', guisp = M.colors.base04 }
-    hi.TSDefinitionUsage                  = { guifg = nil, guibg = nil, gui = 'underline', guisp = M.colors.base04 }
-    hi.TSCurrentScope                     = { guifg = nil, guibg = nil, gui = 'bold', guisp = nil }
+    hi.TSDefinition                       = { guifg = nil, guibg = nil, gui = 'underline', guisp = M.colors.base04,
+                                              ctermfg = nil, ctermbg = nil }
+    hi.TSDefinitionUsage                  = { guifg = nil, guibg = nil, gui = 'underline', guisp = M.colors.base04,
+                                              ctermfg = nil, ctermbg = nil }
+    hi.TSCurrentScope                     = { guifg = nil, guibg = nil, gui = 'bold', guisp = nil,
+                                              ctermfg = nil, ctermbg = nil }
 
-    hi.LspInlayHint                       = { guifg = M.colors.base03, guibg = nil, gui = 'italic', guisp = nil }
+    hi.LspInlayHint                       = { guifg = M.colors.base03, guibg = nil, gui = 'italic', guisp = nil,
+                                              ctermfg = M.colors.cterm03, ctermbg = nil }
 
     if vim.fn.has('nvim-0.8.0') then
         hi['@comment'] = 'TSComment'
@@ -413,34 +587,50 @@ function M.setup(colors, config)
     end
 
     if M.config.ts_rainbow then
-        hi.rainbowcol1 = { guifg = M.colors.base06 }
-        hi.rainbowcol2 = { guifg = M.colors.base09 }
-        hi.rainbowcol3 = { guifg = M.colors.base0A }
-        hi.rainbowcol4 = { guifg = M.colors.base07 }
-        hi.rainbowcol5 = { guifg = M.colors.base0C }
-        hi.rainbowcol6 = { guifg = M.colors.base0D }
-        hi.rainbowcol7 = { guifg = M.colors.base0E }
+        hi.rainbowcol1 = { guifg = M.colors.base06, ctermfg = M.colors.cterm06 }
+        hi.rainbowcol2 = { guifg = M.colors.base09, ctermfg = M.colors.cterm09  }
+        hi.rainbowcol3 = { guifg = M.colors.base0A, ctermfg = M.colors.cterm0A }
+        hi.rainbowcol4 = { guifg = M.colors.base07, ctermfg = M.colors.cterm07  }
+        hi.rainbowcol5 = { guifg = M.colors.base0C, ctermfg = M.colors.cterm0C  }
+        hi.rainbowcol6 = { guifg = M.colors.base0D, ctermfg = M.colors.cterm0D  }
+        hi.rainbowcol7 = { guifg = M.colors.base0E, ctermfg = M.colors.cterm0E  }
     end
 
-    hi.NvimInternalError = { guifg = M.colors.base00, guibg = M.colors.base08, gui = 'none', guisp = nil }
+    hi.NvimInternalError = { guifg = M.colors.base00, guibg = M.colors.base08, gui = 'none', guisp = nil,
+                             ctermfg = M.colors.cterm00, ctermbg = M.colors.cterm08 }
 
-    hi.NormalFloat       = { guifg = M.colors.base05, guibg = M.colors.base00, gui = nil, guisp = nil }
-    hi.FloatBorder       = { guifg = M.colors.base05, guibg = M.colors.base00, gui = nil, guisp = nil }
-    hi.NormalNC          = { guifg = M.colors.base05, guibg = M.colors.base00, gui = nil, guisp = nil }
-    hi.TermCursor        = { guifg = M.colors.base00, guibg = M.colors.base05, gui = 'none', guisp = nil }
-    hi.TermCursorNC      = { guifg = M.colors.base00, guibg = M.colors.base05, gui = nil, guisp = nil }
+    hi.NormalFloat       = { guifg = M.colors.base05, guibg = M.colors.base00, gui = nil, guisp = nil,
+                             ctermfg = M.colors.cterm05, ctermbg = M.colors.cterm00 }
+    hi.FloatBorder       = { guifg = M.colors.base05, guibg = M.colors.base00, gui = nil, guisp = nil,
+                             ctermfg = M.colors.cterm05, ctermbg = M.colors.cterm00 }
+    hi.NormalNC          = { guifg = M.colors.base05, guibg = M.colors.base00, gui = nil, guisp = nil,
+                             ctermfg = M.colors.cterm05, ctermbg = M.colors.cterm00 }
+    hi.TermCursor        = { guifg = M.colors.base00, guibg = M.colors.base05, gui = 'none', guisp = nil,
+                             ctermfg = M.colors.cterm00, ctermbg = M.colors.cterm05 }
+    hi.TermCursorNC      = { guifg = M.colors.base00, guibg = M.colors.base05, gui = nil, guisp = nil,
+                             ctermfg = M.colors.cterm00, ctermbg = M.colors.cterm05 }
 
-    hi.User1             = { guifg = M.colors.base08, guibg = M.colors.base02, gui = 'none', guisp = nil }
-    hi.User2             = { guifg = M.colors.base0E, guibg = M.colors.base02, gui = 'none', guisp = nil }
-    hi.User3             = { guifg = M.colors.base05, guibg = M.colors.base02, gui = 'none', guisp = nil }
-    hi.User4             = { guifg = M.colors.base0C, guibg = M.colors.base02, gui = 'none', guisp = nil }
-    hi.User5             = { guifg = M.colors.base05, guibg = M.colors.base02, gui = 'none', guisp = nil }
-    hi.User6             = { guifg = M.colors.base05, guibg = M.colors.base01, gui = 'none', guisp = nil }
-    hi.User7             = { guifg = M.colors.base05, guibg = M.colors.base02, gui = 'none', guisp = nil }
-    hi.User8             = { guifg = M.colors.base00, guibg = M.colors.base02, gui = 'none', guisp = nil }
-    hi.User9             = { guifg = M.colors.base00, guibg = M.colors.base02, gui = 'none', guisp = nil }
+    hi.User1             = { guifg = M.colors.base08, guibg = M.colors.base02, gui = 'none', guisp = nil,
+                             ctermfg = M.colors.cterm08, ctermbg = M.colors.cterm02 }
+    hi.User2             = { guifg = M.colors.base0E, guibg = M.colors.base02, gui = 'none', guisp = nil,
+                             ctermfg = M.colors.cterm0E, ctermbg = M.colors.cterm02 }
+    hi.User3             = { guifg = M.colors.base05, guibg = M.colors.base02, gui = 'none', guisp = nil,
+                             ctermfg = M.colors.cterm05, ctermbg = M.colors.cterm02 }
+    hi.User4             = { guifg = M.colors.base0C, guibg = M.colors.base02, gui = 'none', guisp = nil,
+                             ctermfg = M.colors.cterm0C, ctermbg = M.colors.cterm02 }
+    hi.User5             = { guifg = M.colors.base05, guibg = M.colors.base02, gui = 'none', guisp = nil,
+                             ctermfg = M.colors.cterm05, ctermbg = M.colors.cterm02 }
+    hi.User6             = { guifg = M.colors.base05, guibg = M.colors.base01, gui = 'none', guisp = nil,
+                             ctermfg = M.colors.cterm05, ctermbg = M.colors.cterm01 }
+    hi.User7             = { guifg = M.colors.base05, guibg = M.colors.base02, gui = 'none', guisp = nil,
+                             ctermfg = M.colors.cterm05, ctermbg = M.colors.cterm02 }
+    hi.User8             = { guifg = M.colors.base00, guibg = M.colors.base02, gui = 'none', guisp = nil,
+                             ctermfg = M.colors.cterm00, ctermbg = M.colors.cterm02 }
+    hi.User9             = { guifg = M.colors.base00, guibg = M.colors.base02, gui = 'none', guisp = nil,
+                             ctermfg = M.colors.cterm00, ctermbg = M.colors.cterm02 }
 
-    hi.TreesitterContext = { guifg = nil, guibg = M.colors.base01, gui = 'italic', guisp = nil }
+    hi.TreesitterContext = { guifg = nil, guibg = M.colors.base01, gui = 'italic', guisp = nil,
+                             ctermfg = nil, ctermbg = M.colors.cterm01 }
 
     if M.config.telescope then
         if not M.config.telescope_borders and hex_re:match_str(M.colors.base00) and hex_re:match_str(M.colors.base01) and
@@ -473,21 +663,36 @@ function M.setup(colors, config)
     end
 
     if M.config.notify then
-        hi.NotifyERRORBorder = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil }
-        hi.NotifyWARNBorder  = { guifg = M.colors.base0E, guibg = nil, gui = 'none', guisp = nil }
-        hi.NotifyINFOBorder  = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil }
-        hi.NotifyDEBUGBorder = { guifg = M.colors.base0C, guibg = nil, gui = 'none', guisp = nil }
-        hi.NotifyTRACEBorder = { guifg = M.colors.base0C, guibg = nil, gui = 'none', guisp = nil }
-        hi.NotifyERRORIcon   = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil }
-        hi.NotifyWARNIcon    = { guifg = M.colors.base0E, guibg = nil, gui = 'none', guisp = nil }
-        hi.NotifyINFOIcon    = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil }
-        hi.NotifyDEBUGIcon   = { guifg = M.colors.base0C, guibg = nil, gui = 'none', guisp = nil }
-        hi.NotifyTRACEIcon   = { guifg = M.colors.base0C, guibg = nil, gui = 'none', guisp = nil }
-        hi.NotifyERRORTitle  = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil }
-        hi.NotifyWARNTitle   = { guifg = M.colors.base0E, guibg = nil, gui = 'none', guisp = nil }
-        hi.NotifyINFOTitle   = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil }
-        hi.NotifyDEBUGTitle  = { guifg = M.colors.base0C, guibg = nil, gui = 'none', guisp = nil }
-        hi.NotifyTRACETitle  = { guifg = M.colors.base0C, guibg = nil, gui = 'none', guisp = nil }
+        hi.NotifyERRORBorder = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil,
+                                 ctermfg = M.colors.cterm08, ctermbg = nil }
+        hi.NotifyWARNBorder  = { guifg = M.colors.base0E, guibg = nil, gui = 'none', guisp = nil,
+                                 ctermfg = M.colors.cterm0E, ctermbg = nil }
+        hi.NotifyINFOBorder  = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil,
+                                 ctermfg = M.colors.cterm05, ctermbg = nil }
+        hi.NotifyDEBUGBorder = { guifg = M.colors.base0C, guibg = nil, gui = 'none', guisp = nil,
+                                 ctermfg = M.colors.cterm0C, ctermbg = nil }
+        hi.NotifyTRACEBorder = { guifg = M.colors.base0C, guibg = nil, gui = 'none', guisp = nil,
+                                 ctermfg = M.colors.cterm0C, ctermbg = nil }
+        hi.NotifyERRORIcon   = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil,
+                                 ctermfg = M.colors.cterm08, ctermbg = nil }
+        hi.NotifyWARNIcon    = { guifg = M.colors.base0E, guibg = nil, gui = 'none', guisp = nil,
+                                 ctermfg = M.colors.cterm0E, ctermbg = nil }
+        hi.NotifyINFOIcon    = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil,
+                                 ctermfg = M.colors.cterm05, ctermbg = nil }
+        hi.NotifyDEBUGIcon   = { guifg = M.colors.base0C, guibg = nil, gui = 'none', guisp = nil,
+                                 ctermfg = M.colors.cterm0C, ctermbg = nil }
+        hi.NotifyTRACEIcon   = { guifg = M.colors.base0C, guibg = nil, gui = 'none', guisp = nil,
+                                 ctermfg = M.colors.cterm0C, ctermbg = nil }
+        hi.NotifyERRORTitle  = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil,
+                                 ctermfg = M.colors.cterm08, ctermbg = nil }
+        hi.NotifyWARNTitle   = { guifg = M.colors.base0E, guibg = nil, gui = 'none', guisp = nil,
+                                 ctermfg = M.colors.cterm0E, ctermbg = nil }
+        hi.NotifyINFOTitle   = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil,
+                                 ctermfg = M.colors.cterm05, ctermbg = nil }
+        hi.NotifyDEBUGTitle  = { guifg = M.colors.base0C, guibg = nil, gui = 'none', guisp = nil,
+                                 ctermfg = M.colors.cterm0C, ctermbg = nil }
+        hi.NotifyTRACETitle  = { guifg = M.colors.base0C, guibg = nil, gui = 'none', guisp = nil,
+                                 ctermfg = M.colors.cterm0C, ctermbg = nil }
         hi.NotifyERRORBody   = 'Normal'
         hi.NotifyWARNBody    = 'Normal'
         hi.NotifyINFOBody    = 'Normal'
@@ -496,49 +701,81 @@ function M.setup(colors, config)
     end
 
     if M.config.indentblankline then
-        hi.IndentBlanklineChar        = { guifg = M.colors.base02, gui = 'nocombine' }
-        hi.IndentBlanklineContextChar = { guifg = M.colors.base04, gui = 'nocombine' }
-        hi.IblIndent                  = { guifg = M.colors.base02, gui = 'nocombine' }
+        hi.IndentBlanklineChar        = { guifg = M.colors.base02, gui = 'nocombine', M.colors.cterm02 }
+        hi.IndentBlanklineContextChar = { guifg = M.colors.base04, gui = 'nocombine', M.colors.cterm04  }
+        hi.IblIndent                  = { guifg = M.colors.base02, gui = 'nocombine', M.colors.cterm02  }
         hi.IblWhitespace              = 'Whitespace'
-        hi.IblScope                   = { guifg = M.colors.base04, gui = 'nocombine' }
+        hi.IblScope                   = { guifg = M.colors.base04, gui = 'nocombine', M.colors.cterm04  }
     end
 
     if M.config.cmp then
-        hi.CmpDocumentationBorder   = { guifg = M.colors.base05, guibg = M.colors.base00, gui = nil, guisp = nil }
-        hi.CmpDocumentation         = { guifg = M.colors.base05, guibg = M.colors.base00, gui = nil, guisp = nil }
-        hi.CmpItemAbbr              = { guifg = M.colors.base05, guibg = M.colors.base01, gui = nil, guisp = nil }
-        hi.CmpItemAbbrDeprecated    = { guifg = M.colors.base03, guibg = nil, gui = 'strikethrough', guisp = nil }
-        hi.CmpItemAbbrMatch         = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil }
-        hi.CmpItemAbbrMatchFuzzy    = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil }
-        hi.CmpItemKindDefault       = { guifg = M.colors.base05, guibg = nil, gui = nil, guisp = nil }
-        hi.CmpItemMenu              = { guifg = M.colors.base04, guibg = nil, gui = nil, guisp = nil }
-        hi.CmpItemKindKeyword       = { guifg = M.colors.base0E, guibg = nil, gui = nil, guisp = nil }
-        hi.CmpItemKindVariable      = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil }
-        hi.CmpItemKindConstant      = { guifg = M.colors.base09, guibg = nil, gui = nil, guisp = nil }
-        hi.CmpItemKindReference     = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil }
-        hi.CmpItemKindValue         = { guifg = M.colors.base09, guibg = nil, gui = nil, guisp = nil }
-        hi.CmpItemKindFunction      = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil }
-        hi.CmpItemKindMethod        = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil }
-        hi.CmpItemKindConstructor   = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil }
-        hi.CmpItemKindClass         = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil }
-        hi.CmpItemKindInterface     = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil }
-        hi.CmpItemKindStruct        = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil }
-        hi.CmpItemKindEvent         = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil }
-        hi.CmpItemKindEnum          = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil }
-        hi.CmpItemKindUnit          = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil }
-        hi.CmpItemKindModule        = { guifg = M.colors.base05, guibg = nil, gui = nil, guisp = nil }
-        hi.CmpItemKindProperty      = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil }
-        hi.CmpItemKindField         = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil }
-        hi.CmpItemKindTypeParameter = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil }
-        hi.CmpItemKindEnumMember    = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil }
-        hi.CmpItemKindOperator      = { guifg = M.colors.base05, guibg = nil, gui = nil, guisp = nil }
-        hi.CmpItemKindSnippet       = { guifg = M.colors.base04, guibg = nil, gui = nil, guisp = nil }
+        hi.CmpDocumentationBorder   = { guifg = M.colors.base05, guibg = M.colors.base00, gui = nil, guisp = nil,
+                                        ctermfg = M.colors.cterm05, ctermbg = M.colors.cterm00 }
+        hi.CmpDocumentation         = { guifg = M.colors.base05, guibg = M.colors.base00, gui = nil, guisp = nil,
+                                        ctermfg = M.colors.cterm05, ctermbg = M.colors.cterm00 }
+        hi.CmpItemAbbr              = { guifg = M.colors.base05, guibg = M.colors.base01, gui = nil, guisp = nil,
+                                        ctermfg = M.colors.cterm05, ctermbg = M.colors.cterm01 }
+        hi.CmpItemAbbrDeprecated    = { guifg = M.colors.base03, guibg = nil, gui = 'strikethrough', guisp = nil,
+                                        ctermfg = M.colors.cterm03, ctermbg = nil }
+        hi.CmpItemAbbrMatch         = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil,
+                                        ctermfg = M.colors.cterm0D, ctermbg = nil }
+        hi.CmpItemAbbrMatchFuzzy    = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil,
+                                        ctermfg = M.colors.cterm0D, ctermbg = nil }
+        hi.CmpItemKindDefault       = { guifg = M.colors.base05, guibg = nil, gui = nil, guisp = nil,
+                                        ctermfg = M.colors.cterm05, ctermbg = nil }
+        hi.CmpItemMenu              = { guifg = M.colors.base04, guibg = nil, gui = nil, guisp = nil,
+                                        ctermfg = M.colors.cterm04, ctermbg = nil }
+        hi.CmpItemKindKeyword       = { guifg = M.colors.base0E, guibg = nil, gui = nil, guisp = nil,
+                                        ctermfg = M.colors.cterm0E, ctermbg = nil }
+        hi.CmpItemKindVariable      = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil,
+                                        ctermfg = M.colors.cterm08, ctermbg = nil }
+        hi.CmpItemKindConstant      = { guifg = M.colors.base09, guibg = nil, gui = nil, guisp = nil,
+                                        ctermfg = M.colors.cterm09, ctermbg = nil }
+        hi.CmpItemKindReference     = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil,
+                                        ctermfg = M.colors.cterm08, ctermbg = nil }
+        hi.CmpItemKindValue         = { guifg = M.colors.base09, guibg = nil, gui = nil, guisp = nil,
+                                        ctermfg = M.colors.cterm09, ctermbg = nil }
+        hi.CmpItemKindFunction      = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil,
+                                        ctermfg = M.colors.cterm0D, ctermbg = nil }
+        hi.CmpItemKindMethod        = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil,
+                                        ctermfg = M.colors.cterm0D, ctermbg = nil }
+        hi.CmpItemKindConstructor   = { guifg = M.colors.base0D, guibg = nil, gui = nil, guisp = nil,
+                                        ctermfg = M.colors.cterm0D, ctermbg = nil }
+        hi.CmpItemKindClass         = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil,
+                                        ctermfg = M.colors.cterm0A, ctermbg = nil }
+        hi.CmpItemKindInterface     = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil,
+                                        ctermfg = M.colors.cterm0A, ctermbg = nil }
+        hi.CmpItemKindStruct        = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil,
+                                        ctermfg = M.colors.cterm0A, ctermbg = nil }
+        hi.CmpItemKindEvent         = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil,
+                                        ctermfg = M.colors.cterm0A, ctermbg = nil }
+        hi.CmpItemKindEnum          = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil,
+                                        ctermfg = M.colors.cterm0A, ctermbg = nil }
+        hi.CmpItemKindUnit          = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil,
+                                        ctermfg = M.colors.cterm0A, ctermbg = nil }
+        hi.CmpItemKindModule        = { guifg = M.colors.base05, guibg = nil, gui = nil, guisp = nil,
+                                        ctermfg = M.colors.cterm05, ctermbg = nil }
+        hi.CmpItemKindProperty      = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil,
+                                        ctermfg = M.colors.cterm08, ctermbg = nil }
+        hi.CmpItemKindField         = { guifg = M.colors.base08, guibg = nil, gui = nil, guisp = nil,
+                                        ctermfg = M.colors.cterm08, ctermbg = nil }
+        hi.CmpItemKindTypeParameter = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil,
+                                        ctermfg = M.colors.cterm0A, ctermbg = nil }
+        hi.CmpItemKindEnumMember    = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil,
+                                        ctermfg = M.colors.cterm0A, ctermbg = nil }
+        hi.CmpItemKindOperator      = { guifg = M.colors.base05, guibg = nil, gui = nil, guisp = nil,
+                                        ctermfg = M.colors.cterm05, ctermbg = nil }
+        hi.CmpItemKindSnippet       = { guifg = M.colors.base04, guibg = nil, gui = nil, guisp = nil,
+                                        ctermfg = M.colors.cterm04, ctermbg = nil }
     end
 
     if M.config.illuminate then
-        hi.IlluminatedWordText  = { guifg = nil, guibg = nil, gui = 'underline', guisp = M.colors.base04 }
-        hi.IlluminatedWordRead  = { guifg = nil, guibg = nil, gui = 'underline', guisp = M.colors.base04 }
-        hi.IlluminatedWordWrite = { guifg = nil, guibg = nil, gui = 'underline', guisp = M.colors.base04 }
+        hi.IlluminatedWordText  = { guifg = nil, guibg = nil, gui = 'underline', guisp = M.colors.base04,
+                                    ctermfg = nil, ctermbg = nil }
+        hi.IlluminatedWordRead  = { guifg = nil, guibg = nil, gui = 'underline', guisp = M.colors.base04,
+                                    ctermfg = nil, ctermbg = nil }
+        hi.IlluminatedWordWrite = { guifg = nil, guibg = nil, gui = 'underline', guisp = M.colors.base04,
+                                    ctermfg = nil, ctermbg = nil }
     end
 
     if M.config.lsp_semantic then

--- a/lua/base16-colorscheme.lua
+++ b/lua/base16-colorscheme.lua
@@ -702,11 +702,11 @@ function M.setup(colors, config)
     end
 
     if M.config.indentblankline then
-        hi.IndentBlanklineChar        = { guifg = M.colors.base02, gui = 'nocombine', M.colors.cterm02 }
-        hi.IndentBlanklineContextChar = { guifg = M.colors.base04, gui = 'nocombine', M.colors.cterm04  }
-        hi.IblIndent                  = { guifg = M.colors.base02, gui = 'nocombine', M.colors.cterm02  }
+        hi.IndentBlanklineChar        = { guifg = M.colors.base02, gui = 'nocombine', ctermfg = M.colors.cterm02 }
+        hi.IndentBlanklineContextChar = { guifg = M.colors.base04, gui = 'nocombine', ctermfg = M.colors.cterm04  }
+        hi.IblIndent                  = { guifg = M.colors.base02, gui = 'nocombine', ctermfg = M.colors.cterm02  }
         hi.IblWhitespace              = 'Whitespace'
-        hi.IblScope                   = { guifg = M.colors.base04, gui = 'nocombine', M.colors.cterm04  }
+        hi.IblScope                   = { guifg = M.colors.base04, gui = 'nocombine', ctermfg = M.colors.cterm04  }
     end
 
     if M.config.cmp then


### PR DESCRIPTION
preliminary basic support for basic cterm colors

I left telescope and all the themes alone. I also didn't implement anything for the 'cterm' 'val' field (the attribute map).

here's my use of it (pretty simple):
```
require('extern.nvim-base16.lua.base16-colorscheme').setup({
    base00 = '#16161D', base01 = '#2c313c', base02 = '#3e4451', base03 = '#6c7891',
    base04 = '#565c64', base05 = '#abb2bf', base06 = '#9a9bb3', base07 = '#c5c8e6',
    base08 = '#e06c75', base09 = '#d19a66', base0A = '#e5c07b', base0B = '#98c379',
    base0C = '#56b6c2', base0D = '#0184bc', base0E = '#c678dd', base0F = '#a06949',
    cterm00 = 0, cterm01 = 1, cterm02 = 2, cterm03 = 3,
    cterm04 = 4, cterm05 = 5, cterm06 = 6, cterm07 = 7,
    cterm08 = 8, cterm09 = 9, cterm0A = 10, cterm0B = 11,
    cterm0C = 12, cterm0D = 13, cterm0E = 14, cterm0F = 15,
})
```