### PR TITLE
Add .gitignore to avoid checking in 'doc/tags'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
I have this project submoduled with the rest of my plugins. When I generate helptags for all my plugins, this submodule becomes dirty.

Help tags can be generated using `:helptags ALL`.