### PR TITLE
Color Operators like Keywords

### DIFF
--- a/lua/base16-colorscheme.lua
+++ b/lua/base16-colorscheme.lua
@@ -202,7 +202,7 @@ function M.setup(colors, config)
     hi.Keyword                            = { guifg = M.colors.base0E, guibg = nil, gui = nil, guisp = nil }
     hi.Label                              = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil }
     hi.Number                             = { guifg = M.colors.base09, guibg = nil, gui = nil, guisp = nil }
-    hi.Operator                           = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil }
+    hi.Operator                           = { guifg = M.colors.base0E, guibg = nil, gui = 'none', guisp = nil }
     hi.PreProc                            = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil }
     hi.Repeat                             = { guifg = M.colors.base0A, guibg = nil, gui = nil, guisp = nil }
     hi.Special                            = { guifg = M.colors.base0C, guibg = nil, gui = nil, guisp = nil }


### PR DESCRIPTION
They had the default "plain text" color, which made things harder to read. Note that the Operator group is, AFAIK, used to highlight textual operators, and not symbols.

My affected use case was Python syntax, where operators like: `and`, `not`, `or`, and  `in` were not colored. After this change, my syntax highlighting looks now like this:

![image](https://github.com/RRethy/nvim-base16/assets/845012/8a7bef00-1d62-4181-911a-24cb9a006d54)
Note that `==` and `%` in this example are unaffected.