### PR TITLE
Change DiagnosticInfo to base0D

### DIFF
--- a/lua/base16-colorscheme.lua
+++ b/lua/base16-colorscheme.lua
@@ -258,7 +258,7 @@ function M.setup(colors, config)
 
     hi.DiagnosticError                    = { guifg = M.colors.base08, guibg = nil, gui = 'none', guisp = nil }
     hi.DiagnosticWarn                     = { guifg = M.colors.base0E, guibg = nil, gui = 'none', guisp = nil }
-    hi.DiagnosticInfo                     = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil }
+    hi.DiagnosticInfo                     = { guifg = M.colors.base0D, guibg = nil, gui = 'none', guisp = nil }
     hi.DiagnosticHint                     = { guifg = M.colors.base0C, guibg = nil, gui = 'none', guisp = nil }
     hi.DiagnosticUnderlineError           = { guifg = nil, guibg = nil, gui = 'undercurl', guisp = M.colors.base08 }
     hi.DiagnosticUnderlineWarning         = { guifg = nil, guibg = nil, gui = 'undercurl', guisp = M.colors.base0E }


### PR DESCRIPTION
The normal texts of text documents (txt / README / Latex) usually use base05 (white) color. The DiagnosticInfo is using base05, too. When I use the grammar LSP such as `ltex-ls`, the inline diagnostic message is hard to identify. Following image shows the example (in `base-tomorrow-night` colorscheme): 
<img width="1196" alt="base05" src="https://github.com/RRethy/nvim-base16/assets/22725367/b4011956-24c0-4487-9d43-bfaf2254d440">
After change to base0D (Blue):
<img width="1198" alt="base0D" src="https://github.com/RRethy/nvim-base16/assets/22725367/30a5f254-6f59-4506-a98d-4a5f9ae53d28">

The normal texts are not special keywords. The diagnostic message will be overwhelmed by long normal texts. Changes to base0D can make the diagnostic message more clear.

