### PR TITLE
Change TSPunctSpecial to base0F

### DIFF
--- a/lua/base16-colorscheme.lua
+++ b/lua/base16-colorscheme.lua
@@ -310,7 +310,7 @@ function M.setup(colors, config)
     hi.TSProperty                         = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil }
     hi.TSPunctDelimiter                   = { guifg = M.colors.base0F, guibg = nil, gui = 'none', guisp = nil }
     hi.TSPunctBracket                     = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil }
-    hi.TSPunctSpecial                     = { guifg = M.colors.base05, guibg = nil, gui = 'none', guisp = nil }
+    hi.TSPunctSpecial                     = { guifg = M.colors.base0F, guibg = nil, gui = 'none', guisp = nil }
     hi.TSRepeat                           = { guifg = M.colors.base0E, guibg = nil, gui = 'none', guisp = nil }
     hi.TSString                           = { guifg = M.colors.base0B, guibg = nil, gui = 'none', guisp = nil }
     hi.TSStringRegex                      = { guifg = M.colors.base0C, guibg = nil, gui = 'none', guisp = nil }


### PR DESCRIPTION
Similar to #86, the bullets in Latex (`\item`) and Markdown (`*` or `-`) use `TSPunctSpecial`. Both bullets and normal texts use the same color (base05 white). I change `TSPunctSpecial` to base0F to match `TSPunctDelimiter`.
Before change:
<img width="1040" alt="punct-base05" src="https://github.com/RRethy/nvim-base16/assets/22725367/9afce4c4-8436-4e89-a738-e84200c539c9">
After change:
<img width="1034" alt="punct-base0F" src="https://github.com/RRethy/nvim-base16/assets/22725367/d999e87a-ef77-42c9-8164-fe7d3199b087">
