### PR TITLE
Give darken a target so the telescope background can be darker

### DIFF
--- a/lua/base16-colorscheme.lua
+++ b/lua/base16-colorscheme.lua
@@ -43,9 +43,9 @@ local function rgb_to_hex(r, g, b)
     return bit.tohex(bit.bor(bit.lshift(r, 16), bit.lshift(g, 8), b), 6)
 end
 
-local function darken(hex, pct)
+local function darken(hex, pct, towards)
     local r, g, b = hex_to_rgb(string.sub(hex, 2))
-    local br, bg, bb = hex_to_rgb(string.sub(M.colors.base00, 2))
+    local br, bg, bb = hex_to_rgb(string.sub(towards or M.colors.base00, 2))
     r = math.floor(r + (br - r) * pct)
     g = math.floor(g + (bg - g) * pct)
     b = math.floor(b + (bb - b) * pct)
@@ -530,7 +530,7 @@ function M.setup(colors, config)
     if M.config.telescope then
         if not M.config.telescope_borders and hex_re:match_str(M.colors.base00) and hex_re:match_str(M.colors.base01) and
             hex_re:match_str(M.colors.base02) then
-            local darkerbg           = darken(M.colors.base00, 0.1)
+            local darkerbg           = darken(M.colors.base00, 0.1, "#000000")
             local darkercursorline   = darken(M.colors.base01, 0.1)
             local darkerstatusline   = darken(M.colors.base02, 0.1)
             hi.TelescopeBorder       = { guifg = darkerbg, guibg = darkerbg, gui = nil, guisp = nil }


### PR DESCRIPTION
Fixes #120.

`darken(M.colors.base00, 0.1)` cannot return anything but `base00`, because `darken` blends its argument towards `base00` rather than darkening it. Its seven other callers depend on exactly that — `darken(base0B, 0.85)` is how `DiffAdd`'s background is arrived at — so this adds an optional target instead of changing what the function does by default.

Measured on both stock schemes, `nvim --clean` with the plugin prepended to `runtimepath`:

| | `TelescopeNormal` | `TelescopePromptNormal` | `TelescopePreviewLine` | `DiffAdd` | `DiffDelete` |
| --- | --- | --- | --- | --- | --- |
| `default-dark` before | `#181818` | `#343434` | `#282828` | `#2C2F24` | `#261C1C` |
| `default-dark` after | `#151515` | `#343434` | `#282828` | `#2C2F24` | `#261C1C` |
| `default-light` before | `#F8F8F8` | `#DBDBDB` | `#E8E8E8` | `#EAEDE3` | `#F0E6E5` |
| `default-light` after | `#DFDFDF` | `#DBDBDB` | `#E8E8E8` | `#EAEDE3` | `#F0E6E5` |

`Normal` is `#181818` and `#F8F8F8` respectively, so `TelescopeNormal` moves off it and nothing else moves at all.
